### PR TITLE
Road to automated release on tag push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: java
 install: mvn -s src/main/resources/settings.xml install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn -s src/main/resources/settings.xml clean verify
+after_success:
+- cp ./target/classes/bintray.json bintray.json
+
+before_deploy:
+- mvn clean deploy -B -DcreateChecksum=true -DgeneratePom=true -DaltDeploymentRepository="local::default::file://repository"
+
+deploy:
+  - provider: bintray
+    file: bintray.json
+    user: xtf-cz
+    key:
+      secure: "PZYm9yI8l9xe6wG/rQdax+n5v3/3mVi+AsJAZK7bIFQgpGvVnlOVGfpWEm6+y5tCZCnzz37Cm55wEjj2oUBTP6w7cMrT0aIVNPtn8NTSGt8R1pHGT1MSdGnQqb1O9vzbZ077m3VVvMcZH7ahVi1cwdTKEf+0grWp1CVb0F9Ddz+3tuS6hr8TVUX3VzttKG6rPOSG8tmGSn3mwuwk2qrvShy7wdO1MB+0YIMjImN2t2jQ+WIdCwZrjU/8XXY1NpssVmZEhXA1WnnOvZoHSqMzvt86blNDopH2FQHpnGN9dSp0yDlBHdw3a123faw6ZaCbeX313PCJ9duKHhw8JD5oZvttNQPm4OOOcVyS0c6wsHp8DqXUNf8AdBXsOKP8t9OpQDjRCqhuBLVjY7JHsyN7hzcy7dk4cnX1fBjv+C9zsolgIRNFHURwKUKEUzd1r5Jxn9PwA8VlwkMNT334AghbhtgSPOuPjK3tpcqRG57aVvhdw17TNsZ9wBiCV8BCWEby/kLmbAQvIMpxh/PeUpoZfkS9GljOh1wMvUmFWTayVXQtA7PnMnUVVWvGZZArHE0HSQXCtupzpi2gGo0r0qM0kybyayNlJb98Jvzji6P2inNGWEthMRP4H8/Yh2OWicY9MiL/T2UsuT9VUwE83Cr7x4O0vy9aj7Jk5Y41J5PIykw="
+    on:
+      branch: master
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ deploy:
     on:
       branch: master
       tags: true
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ after_success:
 - cp ./target/classes/bintray.json bintray.json
 
 before_deploy:
-- mvn clean deploy -B -DcreateChecksum=true -DgeneratePom=true -DaltDeploymentRepository="local::default::file://repository"
+- mvn clean deploy -B -DskipTests=true -Dmaven.javadoc.skip=true -DcreateChecksum=true -DgeneratePom=true -DaltDeploymentRepository="local::default::file://repository"
 
 deploy:
   - provider: bintray

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>cz.xtf</groupId>
 	<artifactId>utilities</artifactId>
-	<version>0.2-SNAPSHOT</version>
+	<version>0.1-SNAPSHOT</version>
 
 	<name>XTF</name>
 
@@ -217,6 +217,12 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${basedir}/src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>cz.xtf</groupId>
 	<artifactId>utilities</artifactId>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.2-SNAPSHOT</version>
 
 	<name>XTF</name>
+
+	<scm>
+		<connection>scm:git:git@github.com:xtf-cz/xtf.git</connection>
+		<developerConnection>scm:git:git@github.com:xtf-cz/xtf.git</developerConnection>
+		<url>http://github.com/xtf-cz/xtf.git</url>
+		<tag>${project.version}</tag>
+	</scm>
 
 	<dependencies>
 		<dependency>

--- a/src/main/resources/bintray.json
+++ b/src/main/resources/bintray.json
@@ -1,0 +1,28 @@
+{
+  "package": {
+    "name": "utilities",
+    "repo": "xtf",
+    "subject": "xtf-cz",
+    "vcs_url": "https://github.com/xtf-cz/xtf",
+    "github_use_tag_release_notes": true,
+    "licenses": [
+      "MIT"
+    ],
+    "public_download_numbers": false,
+    "public_stats": false
+  },
+  "version": {
+    "name": "@project.version@",
+    "vcs_tag": "@project.version@",
+  },
+  "files": [
+    {
+      "includePattern": "repository/*",
+      "uploadPattern": "cz/xtf/utilities/@project.version@/$1",
+      "matrixParams": {
+        "override": 1
+      }
+    }
+  ],
+  "publish": true
+}


### PR DESCRIPTION
This PR adds:
- SCM coordinates to be used with Maven Release Plugin
- configuration to upload files to bintray repository

Outline of release:
- push tagged version without `SNAPSHOT` suffix
  - project.version == tag (e.g. `0.1`)
  - this can be done manually (edit version, git tag, git push, update master to next iteration) or via release plugin `mvn prepare:release`
- upon successful new tag Travis job should do the heavy lifting of building and uploading to repository
  - note that bintray.json descriptor is stored as a Maven resource to be build with proper project version 