### PR TITLE
Init Git repository when SSH private key not found

### DIFF
--- a/src/main/java/cz/xtf/ssh/SshPrivateKeyNotFoundException.java
+++ b/src/main/java/cz/xtf/ssh/SshPrivateKeyNotFoundException.java
@@ -1,0 +1,13 @@
+package cz.xtf.ssh;
+
+public class SshPrivateKeyNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = -1110984173100523047L;
+
+	public SshPrivateKeyNotFoundException() {
+	}
+
+	public SshPrivateKeyNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/cz/xtf/ssh/SshUtil.java
+++ b/src/main/java/cz/xtf/ssh/SshUtil.java
@@ -28,6 +28,8 @@ public class SshUtil {
 			JSCH.addIdentity(getPrivateKeyPath());
 		} catch (JSchException ex) {
 			LOGGER.error("Invalid private key", ex);
+		} catch (SshPrivateKeyNotFoundException ex) {
+			LOGGER.warn("SSH private key not found.");
 		}
 	}
 
@@ -54,7 +56,7 @@ public class SshUtil {
 		if (p.toFile().exists()) {
 			return p.toString();
 		}
-		throw new IllegalStateException("Cannot load SSH private key");
+		throw new SshPrivateKeyNotFoundException("Cannot load SSH private key.");
 	}
 
 	public String getPrivateKey() {


### PR DESCRIPTION
In current implementation user needs to define ssh private key to be able to initialize Git repository. This is however not necessary as it should be possible to push to Git repo using username and password instead of key.
This change allows to initialize Git repo even when SSH private key is not defined.