### PR TITLE
[CLOUD-2261] adding roles builder as a way to define role when needed

### DIFF
--- a/src/main/java/cz/xtf/openshift/OpenshiftApplication.java
+++ b/src/main/java/cz/xtf/openshift/OpenshiftApplication.java
@@ -28,6 +28,8 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.Role;
+import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.Route;
 
 public class OpenshiftApplication {
@@ -48,6 +50,8 @@ public class OpenshiftApplication {
 	private List<Route> routes = new LinkedList<>();
 	private List<ConfigMap> configMaps = new LinkedList<>();
 	private List<HorizontalPodAutoscaler> autoScalers = new LinkedList<>();
+	private List<Role> roles = new LinkedList<>();
+	private List<RoleBinding> roleBindings = new LinkedList<>();
 
 	private BuildConfig buildConfig;
 	private DeploymentConfig mainDeployment;
@@ -96,6 +100,12 @@ public class OpenshiftApplication {
 
 		// add autoscaler
 		autoScalers.addAll(builder.buildAutoScalers());
+
+		// add roles
+		roles.addAll(builder.buildRoles());
+
+		// add role bindings
+		roleBindings.addAll(builder.buildRoleBindings());
 	}
 
 	public OpenshiftApplication createServiceAccountFromSecrets(final String accountName) {
@@ -164,6 +174,7 @@ public class OpenshiftApplication {
 		routes = routes.stream().map(openshift::createRoute).collect(Collectors.toList());
 		configMaps = configMaps.stream().map(openshift::createConfigMap).collect(Collectors.toList());
 		autoScalers = autoScalers.stream().map(openshift::createHorizontalPodAutoscaler).collect(Collectors.toList());
+
 		// find main resources
 		if (buildConfig != null) {
 			buildConfig = findMainResource(buildConfigs, buildConfig.getMetadata().getName());
@@ -179,6 +190,9 @@ public class OpenshiftApplication {
 		}
 
 		createServiceAccount();
+
+		roles = roles.stream().map(openshift::createRole).collect(Collectors.toList());
+		roleBindings = roleBindings.stream().map(openshift::createRoleBinding).collect(Collectors.toList());
 	}
 
 	public Build triggerManualBuild() {

--- a/src/main/java/cz/xtf/openshift/builder/RoleBindingBuilder.java
+++ b/src/main/java/cz/xtf/openshift/builder/RoleBindingBuilder.java
@@ -1,0 +1,120 @@
+package cz.xtf.openshift.builder;
+
+import io.fabric8.openshift.api.model.RoleBinding;
+import io.fabric8.openshift.api.model.RoleBindingFluent;
+
+/**
+ * Definition of RoleBinding. Example:
+ *
+ *<pre>
+ * apiVersion: v1
+ * kind: RoleBinding
+ * metadata:
+ *   name: pods-listing-binding
+ *   annotations:
+ *     description: "Default service account"
+ * subjects:
+ * - kind: ServiceAccount
+ *   name: default
+ *   namespace: myproject
+ * roleRef:
+ *   kind: Role
+ *   name: pods-listing
+ *   namespace: myproject
+ *</pre>
+ */
+public class RoleBindingBuilder extends AbstractBuilder<RoleBinding, RoleBindingBuilder> {
+    private String subjectKind;
+    private String subjectName;
+    private String subjectNamespace;
+    private String roleRefKind = "Role";
+    private String roleRefName;
+    private String roleRefNamespace;
+
+    public RoleBindingBuilder(String roleName) {
+        this(null, roleName);
+    }
+
+    RoleBindingBuilder(ApplicationBuilder applicationBuilder, String roleName) {
+        super(applicationBuilder, roleName);
+    }
+
+    /**
+     * What <code>kind</code> gains the role defined at roleRef.
+     * For example: <code>ServiceAccount</code> 
+     */
+    public RoleBindingBuilder subjectKind(String subjectKind) {
+    	this.subjectKind = subjectKind;
+    	return this;
+    }
+    /**
+     * What is name of the <code>kind</code> that gains the <code>role</code> defined at roleRef.
+     * For example account <code>default</code>.
+     */
+    public RoleBindingBuilder subjectName(String subjectName) {
+    	this.subjectName = subjectName;
+    	return this;
+    }
+    /**
+     * What is namespace of the defined <code>kind</code>.
+     * For example namespace <code>myproject</code>.
+     */
+    public RoleBindingBuilder subjectNamespace(String subjectNamespace) {
+    	this.subjectNamespace = subjectNamespace;
+    	return this;
+    }
+    /**
+     * What is <code>kind</code> we want to reference to the subject.
+     * For example kind <code>Role</code>.
+     */
+    public RoleBindingBuilder roleRefKind(String roleRefKind) {
+    	this.roleRefKind = roleRefKind;
+    	return this;
+    }
+    /**
+     * What is name of the role reference.
+     */
+    public RoleBindingBuilder roleRefName(String roleRefName) {
+    	this.roleRefName = roleRefName;
+    	return this;
+    }
+    /**
+     * What is namespace of the role reference.
+     */
+    public RoleBindingBuilder roleRefNamespace(String roleRefNamespace) {
+    	this.roleRefNamespace = roleRefNamespace;
+    	return this;
+    }
+
+	@Override
+	public RoleBinding build() {
+		RoleBindingFluent.SubjectsNested<io.fabric8.openshift.api.model.RoleBindingBuilder> subject = new io.fabric8.openshift.api.model.RoleBindingBuilder()
+			.withNewMetadata()
+				.withName(this.getName())
+			.endMetadata()
+			.addNewSubject()
+				.withKind(subjectKind)
+				.withName(subjectName);
+
+		if(subjectNamespace != null && !subjectNamespace.isEmpty())
+			subject.withNamespace(subjectNamespace);
+
+		RoleBindingFluent.RoleRefNested<io.fabric8.openshift.api.model.RoleBindingBuilder> roleRef = subject
+			.endSubject()
+			.withNewRoleRef()
+				.withKind(roleRefKind)
+				.withName(roleRefName);
+
+		if(roleRefNamespace != null && !roleRefNamespace.isEmpty())
+			roleRef.withNamespace(roleRefNamespace);
+
+		return roleRef
+			.endRoleRef()
+			.build();
+    }
+
+    @Override
+    protected RoleBindingBuilder getThis() {
+        return this;
+    }
+}

--- a/src/main/java/cz/xtf/openshift/builder/RoleBuilder.java
+++ b/src/main/java/cz/xtf/openshift/builder/RoleBuilder.java
@@ -1,0 +1,60 @@
+package cz.xtf.openshift.builder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import io.fabric8.openshift.api.model.Role;
+
+/**
+ * Definition of Role. Example:
+ *
+ *<pre>
+ * apiVersion: v1
+ * kind: Role
+ * metadata:
+ *   name: pods-listing
+ * rules:
+ *   resources: ["pods", "pods/log"]
+ *   verbs: ["list", "get"]
+ *</pre>
+ */
+public class RoleBuilder extends AbstractBuilder<Role, RoleBuilder> {
+	private Collection<String> resources;
+	private Collection<String> verbs;
+
+	public RoleBuilder(String roleName) {
+		this(null, roleName);
+	}
+
+	RoleBuilder(ApplicationBuilder applicationBuilder, String roleName) {
+		super(applicationBuilder, roleName);
+	}
+
+	public RoleBuilder resources(String... resources) {
+		this.resources = new ArrayList<String>(Arrays.asList(resources));
+		return this;
+	}
+
+	public RoleBuilder verbs(String... verbs) {
+		this.verbs = new ArrayList<String>(Arrays.asList(verbs));
+		return this;
+	}
+
+	@Override
+	public Role build() {
+		return new io.fabric8.openshift.api.model.RoleBuilder()
+				.withNewMetadata()
+					.withName(this.getName())
+				.endMetadata()
+				.addNewRule()
+					.addToVerbs(verbs.toArray(new String[0]))
+					.addToResources(resources.toArray(new String[0]))
+				.endRule()
+				.build();
+	}
+
+	@Override
+	protected RoleBuilder getThis() {
+		return this;
+	}
+}


### PR DESCRIPTION
While working on fix for https://issues.jboss.org/browse/CLOUD-2261 I would need to have chance to add roles and role binding as the image I use needs to list pods via api call.

Now I would like to add this ability to the xtf for me being able to use it then in xpaas qe test `test-eap/PostgreSQLXARecoveryLoadTest`. This is maintained by @tremes but I do some tweaks in it. I'm aware of the fact the changes goes to the deprecated part of the code (`OpenshiftUtil`) but the whole test is written in way of using it.

If you guide me how to do it in better way I will be more than happy.