### PR TITLE
quick fix for TestConfiguration env properties

### DIFF
--- a/src/main/java/cz/xtf/TestConfiguration.java
+++ b/src/main/java/cz/xtf/TestConfiguration.java
@@ -55,8 +55,8 @@ public class TestConfiguration extends XTFConfiguration {
 	public static final String CI_PASSWORD = "ci.password";
 
 	static {
-		get().copyValues(fromEnvironment());
 		get().copyValues(defaultValues());
+		get().copyValues(fromEnvironment(), true);
 	}
 
 	private TestConfiguration() {

--- a/src/main/java/cz/xtf/XTFConfiguration.java
+++ b/src/main/java/cz/xtf/XTFConfiguration.java
@@ -722,7 +722,7 @@ public class XTFConfiguration {
 		copyValues(source, false);
 	}
 
-	private void copyValues(final Properties source, final boolean overwrite) {
+	protected void copyValues(final Properties source, final boolean overwrite) {
 		source.stringPropertyNames().stream()
 				.filter(key -> overwrite || !this.properties.containsKey(key))
 				.forEach(key -> this.properties.setProperty(key, source.getProperty(key)));


### PR DESCRIPTION
probably still not exactly what we want but at least make the envs make overwrite any previous ones so that our jenkins job can still function properly.

correct order is  test properties > system properties > env > global-test.properties > default

for images in TestConfiguration without this fix it is  

 test properties > system properties >  global-test.properties  (with no way of using env)

this fix makes it

env >  test properties > system properties > global-test.properties 

which at least works with the jenkins job  (as we need env > global-test.properties at least)