### PR TITLE
quickfix make sure we touch the static init block in TestConfiguration

### DIFF
--- a/src/main/java/cz/xtf/TestConfiguration.java
+++ b/src/main/java/cz/xtf/TestConfiguration.java
@@ -59,6 +59,10 @@ public class TestConfiguration extends XTFConfiguration {
 		get().copyValues(fromEnvironment(), true);
 	}
 
+	public static XTFConfiguration get() {
+		return XTFConfiguration.get();
+	}
+
 	private TestConfiguration() {
 		super();
 	}


### PR DESCRIPTION
make sure the classes that use TestConfiguration use it in a way that calls the static initialization block