### PR TITLE
[utilities] AmqStandaloneBuilder don't use container() for defaults, …

### DIFF
--- a/utilities/src/main/java/cz/xtf/openshift/messaging/AmqStandaloneBuilder.java
+++ b/utilities/src/main/java/cz/xtf/openshift/messaging/AmqStandaloneBuilder.java
@@ -152,14 +152,13 @@ public class AmqStandaloneBuilder {
 		//enable default ssl config in the A-MQ image
 		//enable Jolokia by default
 		//enable default readiness probe
-		container(cb -> cb.envVar("AMQ_KEYSTORE_TRUSTSTORE_DIR", "/opt/amq/conf")
+		appBuilder.deploymentConfig(this.appName).podTemplate().container().envVar("AMQ_KEYSTORE_TRUSTSTORE_DIR", "/opt/amq/conf")
 				.envVar("AMQ_KEYSTORE", "broker.ks")
 				.envVar("AMQ_TRUSTSTORE", "broker.ts")
 				.envVar("AMQ_KEYSTORE_PASSWORD", "password")
 				.envVar("AMQ_TRUSTSTORE_PASSWORD", "password")
 				.port(8778, "jolokia")
-				.addReadinessProbe().createExecProbe("/bin/bash", "-c", "/opt/amq/bin/readinessProbe.sh")
-		);
+				.addReadinessProbe().createExecProbe("/bin/bash", "-c", "/opt/amq/bin/readinessProbe.sh");
 
 		for (Consumer<ContainerBuilder> cbf : containerBuilderFuncs) {
 			cbf.accept(appBuilder.deploymentConfig(this.appName).podTemplate().container(this.appName));


### PR DESCRIPTION
…so that they can be overridden by other container() call