### PR TITLE
[utilities] secrets creation for registry.redhat.io

### DIFF
--- a/utilities/src/main/java/cz/xtf/XTFConfiguration.java
+++ b/utilities/src/main/java/cz/xtf/XTFConfiguration.java
@@ -72,6 +72,9 @@ public class XTFConfiguration {
 	private static final String TEMPLATE_REPO = "xtf.config.template.repo";
 	private static final String TEMPLATE_BRANCH = "xtf.config.template.branch";
 
+	private static final String OREG_AUTH = "xtf.config.oreg.auth";
+	private static final String OREG_REGISTRY = "xtf.config.oreg.registry";
+
 	private static final String OPENSTACK_URL = "xtf.config.openstack.url";
 	private static final String OPENSTACK_TENANT = "xtf.config.openstack.tenant";
 	private static final String OPENSTACK_OPEN_SECURITY_GROUP = "xtf.config.openstack.security.group.open";
@@ -172,6 +175,14 @@ public class XTFConfiguration {
 		}
 
 		return result;
+	}
+
+	public static String oregAuth() {
+		return get().readValue(OREG_AUTH);
+	}
+
+	public static String oregRegistry() {
+		return get().readValue(OREG_REGISTRY);
 	}
 
 	public static String proxyHost() {
@@ -627,6 +638,12 @@ public class XTFConfiguration {
 					break;
 				case "FUSE_DISABLE_JOLOKIA":
 					props.setProperty(FUSE_DISABLE_JOLOKIA, entry.getValue());
+					break;
+				case "OREG_AUTH":
+					props.setProperty(OREG_AUTH, entry.getValue());
+					break;
+				case "OREG_REGISTRY":
+					props.setProperty(OREG_REGISTRY, entry.getValue());
 					break;
 				case "OPENSTACK_URL":
 					props.setProperty(OPENSTACK_URL, entry.getValue());

--- a/utilities/src/main/java/cz/xtf/build/BuildManagerV2.java
+++ b/utilities/src/main/java/cz/xtf/build/BuildManagerV2.java
@@ -42,6 +42,7 @@ public class BuildManagerV2 {
 		if (!TestConfiguration.buildNamespace().equals(TestConfiguration.masterNamespace())) {
 			if (master.getProject(buildNamespace) == null) {
 				master.createProjectRequest();
+				master.createORegSecret();
 			}
 
 			master.addRoleToGroup("system:image-puller", "system:authenticated");

--- a/utilities/src/main/java/cz/xtf/manipulation/ProjectHandler.java
+++ b/utilities/src/main/java/cz/xtf/manipulation/ProjectHandler.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeoutException;
 import static cz.xtf.TestConfiguration.masterNamespace;
 import static cz.xtf.TestConfiguration.masterPassword;
 import static cz.xtf.TestConfiguration.masterUsername;
+
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
@@ -77,6 +78,8 @@ public class ProjectHandler {
 		}
 		// restore original context
 		openshift.setOpenShiftContext(originalContext);
+
+		OpenShiftUtils.master().createORegSecret();
 
 		log.info("action=create-project status=FINISH project={} recreate=true", project);
 	}

--- a/utilities/src/main/java/cz/xtf/openshift/builder/secret/SecretType.java
+++ b/utilities/src/main/java/cz/xtf/openshift/builder/secret/SecretType.java
@@ -7,7 +7,7 @@ public enum SecretType {
 
 	OPAQUE("Opaque"),
 	SERVICE_ACCOUNT("kubernetes.io/service-account-token"),
-	DOCKERCFG("kubernetes.io/dockercfg");
+	DOCKERCFG("kubernetes.io/dockerconfigjson");
 
 	private final String text;
 


### PR DESCRIPTION
Automatically create the pull secrets for an external openshift auth registry (e.g. registry.redhat.io) in the test and build-manager projects. 