### PR TITLE
[utilities] a pod can be ready only if it has at least one container

### DIFF
--- a/utilities/src/main/java/cz/xtf/openshift/ResourceParsers.java
+++ b/utilities/src/main/java/cz/xtf/openshift/ResourceParsers.java
@@ -6,7 +6,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 public class ResourceParsers {
 
 	public static boolean isPodReady(Pod pod) {
-		return pod.getStatus().getContainerStatuses().stream().allMatch(ContainerStatus::getReady);
+		return pod.getStatus().getContainerStatuses().size() > 0 && pod.getStatus().getContainerStatuses().stream().allMatch(ContainerStatus::getReady);
 	}
 
 	public static boolean isPodRunning(Pod pod) {
@@ -18,7 +18,7 @@ public class ResourceParsers {
 	}
 
 	public static boolean hasPodRestartedAtLeastNTimes(Pod pod, int n) {
-		return pod.getStatus().getContainerStatuses().stream().anyMatch(x -> x.getRestartCount() >= n);
+		return pod.getStatus().getContainerStatuses().size() > 0 && pod.getStatus().getContainerStatuses().stream().anyMatch(x -> x.getRestartCount() >= n);
 	}
 
 	private ResourceParsers() {


### PR DESCRIPTION
There are two same classes:
./utilities/src/main/java/cz/xtf/openshift/ResourceParsers.java
./core/src/main/java/cz/xtf/core/openshift/helpers/ResourceParsers.java
This modification was introduced in core..helpers clone. I will create an issue (after some investigation) to unify this. https://github.com/xtf-cz/xtf/issues/157