### PR TITLE
[product] Images

### DIFF
--- a/core/src/main/java/cz/xtf/core/image/UnknownImageException.java
+++ b/core/src/main/java/cz/xtf/core/image/UnknownImageException.java
@@ -1,0 +1,8 @@
+package cz.xtf.core.image;
+
+public class UnknownImageException extends RuntimeException {
+
+	public UnknownImageException(String message) {
+		super(message);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<module>core</module>
 		<module>junit5</module>
 		<module>http-client</module>
+		<module>product</module>
 		<module>test-helpers</module>
 		<module>utilities</module>
 	</modules>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>cz.xtf</groupId>
+        <version>0.9-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>product</artifactId>
+    <name>XTF :: Product</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>cz.xtf</groupId>
+            <artifactId>core</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/product/src/main/java/cz/xtf/product/images/Images.java
+++ b/product/src/main/java/cz/xtf/product/images/Images.java
@@ -1,0 +1,45 @@
+package cz.xtf.product.images;
+
+import cz.xtf.core.image.Image;
+
+public class Images {
+
+	public static Image amq() {
+		return Image.resolve("amq");
+	}
+
+	public static Image bpms() {
+		return Image.resolve("bpms");
+	}
+
+	public static Image brms() {
+		return Image.resolve("brms");
+	}
+
+	public static Image eap() {
+		return Image.resolve("eap");
+	}
+
+	public static Image ews() {
+		return Image.resolve("ews");
+	}
+
+	public static Image jdg() {
+		return Image.resolve("jdg");
+	}
+
+	public static Image jdk() {
+		return Image.resolve("jdk");
+	}
+
+	public static Image jdv() {
+		return Image.resolve("jdv");
+	}
+
+	public static Image sso() {
+		return Image.resolve("sso");
+	}
+
+	private Images() {
+	}
+}


### PR DESCRIPTION
Usage:

### Properties
`xtf.product.image=registry.url/user/repo:tag` (optinal, used if specified)
`xtf.product.version1.image=ga.registry.url/user/repo:tag` (global.properties)
`xtf.product.version2.image=ga.registry.url/user/repo:tag` (global.properties)

`xtf.product.registry=customregistryid` (overrides used registry if not specified 'xtf.product.image')
`xtf.product.user=customuser` (overrides user if not specified 'xtf.product.image')
`xtf.product.tag=customtag` (overrides target tag if not specified 'xtf.product.image')

`xtf.registry.candidate=candidateregistry`
`xtf.registry.ga=garegistry`

### Profiles
`<profile>`
`	<id>version1</id>`
`	<properties>`
`		<xtf.eap.subid>version1</xtf.eap.subid>`
`	</properties>`
`</profile>`

`<profile>`
	`<id>version2</id>`
	`<properties>`
		`<xtf.eap.subid>version2</xtf.eap.subid>`
	`</properties>`
`</profile>`

### Execution
// Runs default tests
`mvn clean test -Ptest-product`

// Runs ImageTest with version image
`mvn clean test -Pproduct,version -Dtest=ImageTest`

// Runs ImageTest with version image using modifying registry and tag
`mvn clean test -Pproduct,version -Dtest=ImageTest -Dxtf.product.user=customuser -Dxtf.product.registry=devel -Dxtf.product.tag=cumstomTag`