### PR TITLE
[utilities] Added oracle extension image

### DIFF
--- a/utilities/src/main/java/cz/xtf/TestConfiguration.java
+++ b/utilities/src/main/java/cz/xtf/TestConfiguration.java
@@ -42,6 +42,7 @@ public class TestConfiguration extends XTFConfiguration {
 	public static final String IMAGE_ZIPKIN = "io.zipkin.java";
 	public static final String IMAGE_SQUID = "org.squid-cache";
 	public static final String IMAGE_TCP_PROXY = "xtf.tcp-proxy";
+	public static final String IMAGE_ORACLE_DRIVER = "xtf.oracle-driver";
 	public static final String IMAGE_MM_SERVICE = "org.hawkular.service";
 	public static final String IMAGE_MM_DATASTORE = "org.hawkular.datastore";
 
@@ -249,6 +250,10 @@ public class TestConfiguration extends XTFConfiguration {
 
 	public static String imageTcpProxy() {
 		return getProperty(IMAGE_TCP_PROXY);
+	}
+
+	public static String imageOracleDriver() {
+		return getProperty(IMAGE_ORACLE_DRIVER);
 	}
 
 	public static String imageMmService() {

--- a/utilities/src/main/java/cz/xtf/openshift/imagestream/ImageRegistry.java
+++ b/utilities/src/main/java/cz/xtf/openshift/imagestream/ImageRegistry.java
@@ -191,6 +191,10 @@ public class ImageRegistry {
 		return normalize(TestConfiguration.get().readValue(TestConfiguration.IMAGE_TCP_PROXY));
 	}
 
+	public String oracleDriver() {
+		return normalize(TestConfiguration.get().readValue(TestConfiguration.IMAGE_ORACLE_DRIVER));
+	}
+
 	public String midlewareManagerService() {
 		return normalize(TestConfiguration.get().readValue(TestConfiguration.IMAGE_MM_SERVICE));
 	}


### PR DESCRIPTION
Image contains oracle stuff in /extensions/. This enables template with external DB to include external driver thru EXTENSIONS_IMAGE.