### PR TITLE
Core CP1

### DIFF
--- a/core/src/main/java/cz/xtf/core/config/XTFConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/XTFConfig.java
@@ -36,7 +36,7 @@ public final class XTFConfig {
 
 		properties.putAll(XTFConfig.getPropertiesFromPath(globalPropertiesPath));
 		properties.putAll(XTFConfig.getPropertiesFromPath(testPropertiesPath));
-		properties.putAll(System.getenv().entrySet().stream().collect(Collectors.toMap(e -> e.getKey().replaceAll("_", ".").toLowerCase(), Map.Entry::getValue)));
+		properties.putAll(System.getenv().entrySet().stream().collect(Collectors.toMap(e -> "xtf." + e.getKey().replaceAll("_", ".").toLowerCase(), Map.Entry::getValue)));
 		properties.putAll(System.getProperties());
 
 		// Set new values based on old properties if new are not set

--- a/core/src/main/java/cz/xtf/core/http/HttpsException.java
+++ b/core/src/main/java/cz/xtf/core/http/HttpsException.java
@@ -1,0 +1,20 @@
+package cz.xtf.core.http;
+
+public class HttpsException extends RuntimeException {
+
+	public HttpsException() {
+		super();
+	}
+
+	public HttpsException(String message) {
+		super(message);
+	}
+
+	public HttpsException(Throwable e) {
+		super(e);
+	}
+
+	public HttpsException(String message, Throwable e) {
+		super(message, e);
+	}
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
@@ -145,7 +144,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 	 *
 	 * @see OpenShift#recreateProject(String)
 	 */
-	public ProjectRequest recreateProject() throws TimeoutException {
+	public ProjectRequest recreateProject() {
 		return recreateProject(new ProjectRequestBuilder().withNewMetadata().withName(getNamespace()).endMetadata().build());
 	}
 
@@ -155,7 +154,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 	 * @param name name of a project to be created
 	 * @return ProjectRequest instatnce
 	 */
-	public ProjectRequest recreateProject(String name) throws TimeoutException {
+	public ProjectRequest recreateProject(String name) {
 		return recreateProject(new ProjectRequestBuilder().withNewMetadata().withName(name).endMetadata().build());
 	}
 
@@ -164,7 +163,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 	 *
 	 * @return ProjectRequest instatnce
 	 */
-	public ProjectRequest recreateProject(ProjectRequest projectRequest) throws TimeoutException {
+	public ProjectRequest recreateProject(ProjectRequest projectRequest) {
 		boolean deleted = deleteProject(projectRequest.getMetadata().getName());
 		if (deleted) {
 			BooleanSupplier bs = () -> getProject(projectRequest.getMetadata().getName()) == null;
@@ -228,6 +227,10 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public Reader getPodLogReader(Pod pod) {
 		return pods().withName(pod.getMetadata().getName()).getLogReader();
+	}
+
+	public Observable<String> observePodLog(String dcName) {
+		return observePodLog(getAnyPod(dcName));
 	}
 
 	public Observable<String> observePodLog(Pod pod) {

--- a/core/src/main/java/cz/xtf/core/openshift/PodShell.java
+++ b/core/src/main/java/cz/xtf/core/openshift/PodShell.java
@@ -72,7 +72,7 @@ public class PodShell {
 
 		getOutputAsList(entryDelimiter).forEach(entry -> {
 			String[] parsedEntry = StringUtils.split(entry, keyValueDelimiter, 2);
-			map.put(parsedEntry[0], parsedEntry[1]);
+			map.put(parsedEntry[0], parsedEntry.length > 1 ? parsedEntry[1] : null);
 		});
 
 		return map;

--- a/core/src/main/java/cz/xtf/core/waiting/SimpleWaiter.java
+++ b/core/src/main/java/cz/xtf/core/waiting/SimpleWaiter.java
@@ -1,7 +1,6 @@
 package cz.xtf.core.waiting;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
 
 public class SimpleWaiter implements Waiter {
@@ -72,7 +71,7 @@ public class SimpleWaiter implements Waiter {
 	}
 
 	@Override
-	public boolean waitFor() throws TimeoutException {
+	public boolean waitFor() {
 		long startTime = System.currentTimeMillis();
 		long endTime = startTime + timeout;
 
@@ -90,10 +89,10 @@ public class SimpleWaiter implements Waiter {
 			try {
 				Thread.sleep(interval);
 			} catch (InterruptedException e) {
-				throw new TimeoutException("Thread has been interrupted!");
+				throw new WaiterException("Thread has been interrupted!");
 			}
 		}
 		logPoint.logEnd(reason + " (Time out)", System.currentTimeMillis() - startTime);
-		throw new TimeoutException();
+		throw new WaiterException(reason);
 	}
 }

--- a/core/src/main/java/cz/xtf/core/waiting/SupplierWaiter.java
+++ b/core/src/main/java/cz/xtf/core/waiting/SupplierWaiter.java
@@ -1,7 +1,6 @@
 package cz.xtf.core.waiting;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -10,11 +9,11 @@ public class SupplierWaiter<X> implements Waiter {
 	private Function<X, Boolean> successCondition;
 	private Function<X, Boolean> failureCondition;
 
-	private long timeout = 60_000L;
-	private long interval = 1_000L;
+	private long timeout;
+	private long interval;
 
-	private String reason = null;
-	private LogPoint logPoint = LogPoint.NONE;
+	private String reason;
+	private LogPoint logPoint;
 
 	public SupplierWaiter(Supplier<X> supplier, Function<X, Boolean> successCondition) {
 		this(supplier, successCondition, x -> false);
@@ -86,7 +85,7 @@ public class SupplierWaiter<X> implements Waiter {
 	}
 
 	@Override
-	public boolean waitFor() throws TimeoutException {
+	public boolean waitFor() {
 		long startTime = System.currentTimeMillis();
 		long endTime = startTime + timeout;
 
@@ -106,10 +105,10 @@ public class SupplierWaiter<X> implements Waiter {
 			try {
 				Thread.sleep(interval);
 			} catch (InterruptedException e) {
-				throw new TimeoutException("Thread has been interrupted!");
+				throw new WaiterException("Thread has been interrupted!");
 			}
 		}
 		logPoint.logEnd(reason + "(Timeout)", timeout);
-		throw new TimeoutException(reason);
+		throw new WaiterException(reason);
 	}
 }

--- a/core/src/main/java/cz/xtf/core/waiting/Waiter.java
+++ b/core/src/main/java/cz/xtf/core/waiting/Waiter.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * An object that waits on condition to be met.
@@ -72,9 +71,8 @@ public interface Waiter {
 	 * Waits till condition is met.
 	 *
 	 * @return true if wanted condition was met, false if unwanted state condition was met
-	 * @throws TimeoutException in case that neither wanted nor unwanted condition have been met or thread has been interrupted
 	 */
-	boolean waitFor() throws TimeoutException;
+	boolean waitFor();
 
 	/**
 	 * Waits till condition is met. This method calls {@link Waiter#waitFor} and false result or declared exception is rethrown as AssertionError.
@@ -97,7 +95,7 @@ public interface Waiter {
 	default void waitForOrAssertFail(String failMessage) {
 		try {
 			if(!waitFor()) throw new AssertionError(failMessage);
-		} catch (TimeoutException e) {
+		} catch (WaiterException e) {
 			throw new AssertionError("Waiter has timed out (" + e.getMessage() + ")!");
 		}
 	}

--- a/core/src/main/java/cz/xtf/core/waiting/WaiterException.java
+++ b/core/src/main/java/cz/xtf/core/waiting/WaiterException.java
@@ -1,0 +1,12 @@
+package cz.xtf.core.waiting;
+
+public class WaiterException extends RuntimeException {
+
+	public WaiterException() {
+		super();
+	}
+
+	public WaiterException(String message) {
+		super(message);
+	}
+}

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeAllCallback.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeAllCallback.java
@@ -10,6 +10,6 @@ public class CleanBeforeAllCallback implements BeforeAllCallback {
 
 	@Override
 	public void beforeAll(ExtensionContext context) {
-		openShift.clean().waitForOrAssertFail();
+		openShift.clean().waitFor();
 	}
 }

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeEachCallback.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeEachCallback.java
@@ -10,6 +10,6 @@ public class CleanBeforeEachCallback implements BeforeEachCallback {
 
 	@Override
 	public void beforeEach(ExtensionContext context) {
-		openShift.clean().waitForOrAssertFail();
+		openShift.clean().waitFor();
 	}
 }


### PR DESCRIPTION
This PR contains new features and bug fixes for XTF core.

### Features:
- Prepends `xtf.` to environment variables mapping to properties. (eg. `SSO_IMAGE` -> `xtf.sso.image`)
- Throw custom runtime exception in `Https` class rather then `IllegalStateException`
- Throw custom runtime exception in `Waiters` rather then `TimeoutException`
- `Https` now provides several waiters
- Extend `ImageContent` class static initiators.

### Bug fixes:
- Use `waitFor()` in core module rather then `waitForOrAssertFail()` in XTF modules
- Cast http connection actually to `HttpURLConnection` not `Https...` one.
- Trim http get content. Method left out new lines at the end of response.
- `PodShell.getOutputAsMap()` now maps value to null if there is nothing behind the split.