### PR TITLE
Core CP2

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BinaryBuild.java
+++ b/core/src/main/java/cz/xtf/core/bm/BinaryBuild.java
@@ -119,7 +119,7 @@ public class BinaryBuild implements ManagedBuild {
 
 	@Override
 	public Waiter hasCompleted(OpenShift openShift) {
-		return openShift.waiters().hasBuildCompleted(openShift.getLatestBuild(id).getMetadata().getName());
+		return openShift.waiters().hasBuildCompleted(id);
 	}
 
 	private ImageStream createIsDefinition() {

--- a/core/src/main/java/cz/xtf/core/http/Https.java
+++ b/core/src/main/java/cz/xtf/core/http/Https.java
@@ -126,7 +126,7 @@ public class Https {
 			connection.disconnect();
 			return code;
 		} catch (IOException e) {
-			throw new HttpsException();
+			throw new HttpsException(e);
 		}
 	}
 
@@ -139,7 +139,7 @@ public class Https {
 			connection.disconnect();
 			return content;
 		} catch (IOException e) {
-			throw new HttpsException();
+			throw new HttpsException(e);
 		}
 	}
 

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -221,6 +221,10 @@ public class OpenShift extends DefaultOpenShiftClient {
 		return pods().withName(name).get();
 	}
 
+	public String getPodLog(String deploymentConfigName) {
+		return getPodLog(this.getAnyPod(deploymentConfigName));
+	}
+
 	public String getPodLog(Pod pod) {
 		return pods().withName(pod.getMetadata().getName()).getLog();
 	}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
@@ -23,16 +23,20 @@ public class OpenShiftWaiters {
 		this.openShift = openShift;
 	}
 
+	public Waiter hasBuildCompleted(String buildConfigName) {
+		return hasBuildCompleted(openShift.getLatestBuild(buildConfigName));
+	}
+
 	/**
 	 * Creates waiter for build completion with preconfigured timeout 10 minutes,
 	 * 5 seconds interval check and both logging points.
 	 *
-	 * @param buildName name of build to be waited upon.
+	 * @param build to be waited upon.
 	 * @return Waiter instance
 	 */
-	public Waiter hasBuildCompleted(String buildName) {
-		Supplier<String> supplier = () -> openShift.getBuild(buildName).getStatus().getPhase();
-		String reason = "Waiting for completion of build " + buildName;
+	public Waiter hasBuildCompleted(Build build) {
+		Supplier<String> supplier = () -> openShift.getBuild(build.getMetadata().getName()).getStatus().getPhase();
+		String reason = "Waiting for completion of build " + build.getMetadata().getName();
 
 		return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MINUTES, 10, reason).logPoint(Waiter.LogPoint.BOTH).interval(5_000);
 	}


### PR DESCRIPTION
Core CP2

### Changes
- Add `OpenShift.getPodLog(String deploymentConfigName)`
- Replace `OpenShiftWaiters.hasBuildCompleted(String buildName)` with
  - `OpenShiftWaiters.hasBuildCompleted(String buildConfigName)`
  - `OpenShiftWaiters.hasBuildCompleted(Build build)`
- Pass exception in `HttpsException` throw.