### PR TITLE
Fixed listZipFilesInDir method to match only .zip files (matched also…

### DIFF
--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -107,7 +107,7 @@ public class ImageContent {
 	}
 
 	public List<String> listZipFilesInDir(String path) {
-		return shell.executeWithBash("ls -R1 ~ " + path + " | grep '\\.zip'").getOutputAsList();
+		return shell.executeWithBash("ls -R1 ~ " + path + " | grep '\\.zip\\$'").getOutputAsList();
 	}
 
 	public List<String> listFilesMd5sumInDir(String path) {


### PR DESCRIPTION
… .zipnew files before)