### PR TITLE
[utilities] GhostDriverService -- Create the route for 'phantomjs' service only if it doesn't exist yet

### DIFF
--- a/utilities/src/main/java/cz/xtf/webdriver/GhostDriverService.java
+++ b/utilities/src/main/java/cz/xtf/webdriver/GhostDriverService.java
@@ -100,13 +100,17 @@ public class GhostDriverService implements Service {
 			OpenshiftUtil.getInstance().createPod(ghostDriverPod);
 
 			hostName = RouteBuilder.createHostName("phantomjs");
-			RouteBuilder rb = new RouteBuilder("phantomjs");
-			rb
-					.addLabel("name", "phantomjs")
-					.forService("phantomjs")
-					.exposedAsHost(hostName);
 
-			OpenshiftUtil.getInstance().createRoute(rb.build());
+			Optional<Route> route = OpenshiftUtil.getInstance().getRoutes().stream().filter(pod -> pod.getMetadata().getName().startsWith("phantomjs")).findFirst();
+			if (!route.isPresent()) {
+				RouteBuilder rb = new RouteBuilder("phantomjs");
+				rb
+						.addLabel("name", "phantomjs")
+						.forService("phantomjs")
+						.exposedAsHost(hostName);
+
+				OpenshiftUtil.getInstance().createRoute(rb.build());
+			}
 
 			try {
 				WaitUtil.waitFor(WaitUtil.urlReturnsCode("http://" + hostName + "/status", 200), null, 1000L, PHANTOMJS_DEPLOY_TIMEOUT_SECONDS * 1000L);


### PR DESCRIPTION
Rationale:

  There are case when you want / need to restart the GhostDriverService (because e.g. the port-forwarding failed and the `phantomjs` pod wouldn't be working properly subsequently).

  To restart it you would call `GhostDriverService.get().close()` as a counterpart operation for the `GhostDriverService.get().start()` call, when starting the service.

  But since the [`GhostDriverService.close()` routine](https://github.com/xtf-cz/xtf/blob/master/utilities/src/main/java/cz/xtf/webdriver/GhostDriverService.java#L127) doesn't delete the `phantomjs` route, [created by the `start()` routine](https://github.com/xtf-cz/xtf/blob/master/utilities/src/main/java/cz/xtf/webdriver/GhostDriverService.java#L109) (only `phantomjs`'s pod and service are [deleted](https://github.com/xtf-cz/xtf/blob/master/utilities/src/main/java/cz/xtf/webdriver/GhostDriverService.java#L132)), an attempt to restart the GhostDriverService pod (via second call of `GhostDriverService.get().start()` method) will end up with the following KubernetesClientException, when the route already exists (but not the `phantomjs` pod, since it was deleted by your `GhostDriverService.get().close()` call):

```
...
2018-11-29 12:53:29,553] INFO - Waiting up to 20 seconds. Reason: Cleaning project.
[2018-11-29 12:53:45,938] WARN - Starting GhostDriverService and waiting 30 seconds for it to become ready. 9 retries left!
[2018-11-29 12:53:46,867] INFO - Oauth token: 2EoOgJMQCjPr6veyeK8L0f4Ih_EVO9jKyJXX_0TgznA
[WARNING] Corrupted STDOUT by directly writing to native stream in forked JVM 1. See FAQ web page and the dump file .../2018-11-29T12-51-55_569-jvmRun1.dumpstream
[2018-11-29 12:55:09,101] WARN - Starting GhostDriverService and waiting 30 seconds for it to become ready. 8 retries left!
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 188.102 s <<< FAILURE! - in ...
[ERROR] ...  Time elapsed: 188.082 s  <<< ERROR!
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: ...:8443/apis/route.openshift.io/v1/namespaces/.../routes. Message: routes.route.openshift.io "phantomjs" already exists. Received status: Status(apiVersion=v1, code=409, details=StatusDetails(causes=[], group=route.openshift.io, kind=routes, name=phantomjs, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=routes.route.openshift.io "phantomjs" already exists, metadata=ListMeta(_continue=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=AlreadyExists, status=Failure, additionalProperties={}).
	at ...(....java:43)

[INFO] 
...
```

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>