### PR TITLE
[core] increase connection and build timeouts

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -76,9 +76,11 @@ public class OpenShift extends DefaultOpenShiftClient {
 				.withMasterUrl(masterUrl)
 				.withTrustCerts(true)
 				.withRequestTimeout(120_000)
+				.withConnectionTimeout(120_000)
 				.withNamespace(namespace)
 				.withUsername(username)
 				.withPassword(password)
+				.withBuildTimeout(10 * 60 * 1000)
 				.build();
 
 		return new OpenShift(openShiftConfig);
@@ -89,6 +91,8 @@ public class OpenShift extends DefaultOpenShiftClient {
 				.withMasterUrl(masterUrl)
 				.withTrustCerts(true)
 				.withRequestTimeout(120_000)
+				.withConnectionTimeout(120_000)
+				.withBuildTimeout(10 * 60 * 1000)
 				.withNamespace(namespace)
 				.withOauthToken(token)
 				.build();


### PR DESCRIPTION
binary build sometimes fails on connection timeouts. This should hopefully fix those. 