### PR TITLE
[junit5] handle KubernetesClientExceptions in prebuilder, optionally …

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
+++ b/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
@@ -12,6 +12,7 @@ public class JUnitConfig {
 	private static final String CI_USERNAME = "xtf.junit.ci.username";
 	private static final String CI_PASSWORD = "xtf.junit.ci.password";
 	private static final String JENKINS_RERUN = "xtf.junit.jenkins.rerun";
+	private static final String PREBUILDER_SYNCHRONIZED = "xtf.junit.prebuilder.synchronized";
 
 	public static boolean cleanOpenShift() {
 		return Boolean.valueOf(XTFConfig.get(CLEAN_OPENSHIFT, "false"));
@@ -36,5 +37,9 @@ public class JUnitConfig {
 
 	public static String jenkinsRerun() {
 		return XTFConfig.get(JENKINS_RERUN);
+	}
+
+	public static boolean prebuilderSynchronized() {
+		return Boolean.parseBoolean(XTFConfig.get(PREBUILDER_SYNCHRONIZED, "false"));
 	}
 }


### PR DESCRIPTION
…synchronize prebuilder builds.

Wait for all the builds even if not synchronized

Treat a build failure as a reason to update the build in BinaryBuild