### PR TITLE
[KEYCLOAK-8742] [PostgreSQL.java] Default to PGCTLTIMEOUT equal to 300 seconds when creating PostgreSQL DB instances

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
@@ -64,6 +64,10 @@ public class PostgreSQL extends AbstractSQLDatabase {
 		vars.put("POSTGRESQL_MAX_CONNECTIONS", "100");
 		vars.put("POSTGRESQL_SHARED_BUFFERS", "16MB");
 		vars.put("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "90");
+		// Temporary workaround for https://github.com/sclorg/postgresql-container/issues/297
+		// Increase the "set_passwords.sh" timeout from the default 60s to 300s to give the
+		// PostgreSQL server chance properly to start under high OCP cluster load
+		vars.put("PGCTLTIMEOUT", "300");
 		return vars;
 	}
 }

--- a/utilities/src/main/java/cz/xtf/openshift/db/PostgreSQL.java
+++ b/utilities/src/main/java/cz/xtf/openshift/db/PostgreSQL.java
@@ -71,6 +71,10 @@ public class PostgreSQL extends AbstractSQLDatabase {
 		vars.put("POSTGRESQL_MAX_CONNECTIONS", "100");
 		vars.put("POSTGRESQL_SHARED_BUFFERS", "16MB");
 		vars.put("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "90");
+		// Temporary workaround for https://github.com/sclorg/postgresql-container/issues/297
+		// Increase the "set_passwords.sh" timeout from the default 60s to 300s to give the
+		// PostgreSQL server chance properly to start under high OCP cluster load
+		vars.put("PGCTLTIMEOUT", "300");
 		return vars;
 	}
 


### PR DESCRIPTION
Workaround for: https://github.com/sclorg/postgresql-container/issues/297

When OpenShift cluster is under higher load, and if PostgreSQL pod restart is requested (the pod is deleted & corresponding deployment config tries to deploy a new pod, for example like in the case of the _com.redhat.xpaas.sso.failover.DependencyFailoverTest.testDbPodRestart_ test), the new pod sometimes ends up / fails with the error message like the following (same like in the above GH issue):

```
pg_ctl: another server might be running; trying to start server anyway
waiting for server to start....LOG:  redirecting log output to logging collector process
HINT:  Future log output will appear in directory "pg_log".
........................................................... stopped waiting
server is still starting up
=> sourcing /usr/share/container-scripts/postgresql/start/set_passwords.sh ...
psql: FATAL:  the database system is starting up
```
Once this happens, the corresponding readiness / liveness probe detects, the PostgreSQL pod is not running, and tries to run another pod. Which again ends up with the very same message. And this enters never-ending loop of trying pod restarts, and their failures to start, because the PostgreSQL server inside the pod didn't have chance to properly start yet before the _set_passwords.sh_ was attempted to be run).

Therefore increase the default `pg_ctl -w start` timeout from _60 seconds_ (the default) to _300 seconds_ by defining the `PGCTLTIMEOUT` environment variable for the PostgreSQL pod.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>