### PR TITLE
[builder] add option to specify client in ApplicationBuilder

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/ApplicationBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/ApplicationBuilder.java
@@ -3,6 +3,7 @@ package cz.xtf.builder.builders;
 import cz.xtf.builder.OpenShiftApplication;
 import cz.xtf.builder.db.OpenShiftAuxiliary;
 import cz.xtf.core.bm.ManagedBuildReference;
+import cz.xtf.core.openshift.OpenShift;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
@@ -295,6 +296,10 @@ public class ApplicationBuilder {
 
 	public OpenShiftApplication buildApplication() {
 		return new OpenShiftApplication(this);
+	}
+
+	public OpenShiftApplication buildApplication(OpenShift openShift) {
+		return new OpenShiftApplication(this, openShift);
 	}
 
 	public ApplicationBuilder addDatabase(OpenShiftAuxiliary database) {

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<!-- Depedency version properties -->
 		<version.httpclient>4.5.5</version.httpclient>
 		<version.jackson>2.8.11</version.jackson>
-		<version.jackson.databind>2.8.11.1</version.jackson.databind>
+		<version.jackson.databind>2.8.11.2</version.jackson.databind>
 		<version.openstack4j>3.1.0</version.openstack4j>
 		<version.resteasy>3.1.4.Final</version.resteasy>
 		<version.openshift-client>4.1.1</version.openshift-client>


### PR DESCRIPTION
This PR adds a convenient method to pass client ref directly via `buildApplication()`.

```java
new OpenShiftApplication(applicationBuilder, openshift).deploy();
// is the same as
applicationBuilder.buildApplication(openshift).deploy();
```