### PR TITLE
[all] upgrade openshift-client to v4.2.2

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/OpenShiftApplication.java
+++ b/builder/src/main/java/cz/xtf/builder/OpenShiftApplication.java
@@ -11,11 +11,11 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.fabric8.openshift.api.model.Role;
-import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.Route;
 import lombok.extern.slf4j.Slf4j;
 
@@ -107,7 +107,7 @@ public class OpenShiftApplication {
 		routes = routes.stream().map(openShift::createRoute).collect(Collectors.toList());
 		configMaps = configMaps.stream().map(openShift::createConfigMap).collect(Collectors.toList());
 		autoScalers = autoScalers.stream().map(openShift::createHorizontalPodAutoscaler).collect(Collectors.toList());
-		roles = roles.stream().map(r -> openShift.roles().create(r)).collect(Collectors.toList());
+		roles = roles.stream().map(r -> openShift.rbac().roles().create(r)).collect(Collectors.toList());
 		roleBindings = roleBindings.stream().map(openShift::createRoleBinding).collect(Collectors.toList());
 	}
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/ApplicationBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/ApplicationBuilder.java
@@ -9,11 +9,11 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
-import io.fabric8.openshift.api.model.Role;
-import io.fabric8.openshift.api.model.RoleBinding;
 import io.fabric8.openshift.api.model.Route;
 import lombok.extern.slf4j.Slf4j;
 

--- a/builder/src/main/java/cz/xtf/builder/builders/RoleBindingBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/RoleBindingBuilder.java
@@ -1,7 +1,7 @@
 package cz.xtf.builder.builders;
 
-import io.fabric8.openshift.api.model.RoleBinding;
-import io.fabric8.openshift.api.model.RoleBindingFluent;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingFluent;
 
 /**
  * Definition of RoleBinding. Example:
@@ -86,6 +86,7 @@ public class RoleBindingBuilder extends AbstractBuilder<RoleBinding, RoleBinding
 	/**
 	 * What is namespace of the role reference.
 	 */
+	@Deprecated
 	public RoleBindingBuilder roleRefNamespace(String roleRefNamespace) {
 		this.roleRefNamespace = roleRefNamespace;
 		return this;
@@ -93,7 +94,7 @@ public class RoleBindingBuilder extends AbstractBuilder<RoleBinding, RoleBinding
 
 	@Override
 	public RoleBinding build() {
-		RoleBindingFluent.SubjectsNested<io.fabric8.openshift.api.model.RoleBindingBuilder> subject = new io.fabric8.openshift.api.model.RoleBindingBuilder()
+		RoleBindingFluent.SubjectsNested<io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder> subject = new io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder()
 				.withNewMetadata()
 				.withName(this.getName())
 				.endMetadata()
@@ -104,14 +105,11 @@ public class RoleBindingBuilder extends AbstractBuilder<RoleBinding, RoleBinding
 		if (subjectNamespace != null && !subjectNamespace.isEmpty())
 			subject.withNamespace(subjectNamespace);
 
-		RoleBindingFluent.RoleRefNested<io.fabric8.openshift.api.model.RoleBindingBuilder> roleRef = subject
+		RoleBindingFluent.RoleRefNested<io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder> roleRef = subject
 				.endSubject()
 				.withNewRoleRef()
 				.withKind(roleRefKind)
 				.withName(roleRefName);
-
-		if (roleRefNamespace != null && !roleRefNamespace.isEmpty())
-			roleRef.withNamespace(roleRefNamespace);
 
 		return roleRef
 				.endRoleRef()

--- a/builder/src/main/java/cz/xtf/builder/builders/RoleBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/RoleBuilder.java
@@ -1,6 +1,6 @@
 package cz.xtf.builder.builders;
 
-import io.fabric8.openshift.api.model.Role;
+import io.fabric8.kubernetes.api.model.rbac.Role;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +43,7 @@ public class RoleBuilder extends AbstractBuilder<Role, RoleBuilder> {
 
 	@Override
 	public Role build() {
-		return new io.fabric8.openshift.api.model.RoleBuilder()
+		return new io.fabric8.kubernetes.api.model.rbac.RoleBuilder()
 				.withNewMetadata()
 					.withName(this.getName())
 				.endMetadata()

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/ConfigMapVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/ConfigMapVolume.java
@@ -32,7 +32,7 @@ public class ConfigMapVolume extends Volume {
 				int num = Character.getNumericValue(b);
 				defaultModeIntVal = num | defaultModeIntVal << 3;
 			}
-			cfm.withNewDefaultMode(defaultModeIntVal);
+			cfm.withDefaultMode(defaultModeIntVal);
 		}
 		cfm.endConfigMap();
 	}

--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -16,7 +16,7 @@ public class BuildManager {
 			openShift.createProjectRequest();
 		}
 
-		openShift.addRoleToGroup("system:image-puller", "system:authenticated");
+		openShift.addRoleToGroup("system:image-puller", "ClusterRole",  "system:authenticated");
 	}
 
 	public ManagedBuildReference deploy(ManagedBuild managedBuild) {

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
 		<!-- Depedency version properties -->
 		<version.httpclient>4.5.5</version.httpclient>
-		<version.openshift-client>4.1.1</version.openshift-client>
+		<version.openshift-client>4.2.2</version.openshift-client>
 		<version.commons-io>2.6</version.commons-io>
 		<version.commons-lang3>3.4</version.commons-lang3>
 		<version.commons-compress>1.18</version.commons-compress>
@@ -58,7 +58,7 @@
 		<version.assertj-core>3.5.2</version.assertj-core>
 		<version.lombok>1.16.22</version.lombok>
 		<version.gson>2.8.5</version.gson>
-		
+
 		<!-- Plugin version properties -->
 		<version.maven-source-plugin>3.0.1</version.maven-source-plugin>
 		<version.maven-release-plugin>2.5.3</version.maven-release-plugin>


### PR DESCRIPTION
Another take on client upgrade.

I wonder if we should implement some tests based on [mock servers](https://github.com/fabric8io/kubernetes-client/tree/master/openshift-server-mock/src/main/java/io/fabric8/openshift/client/server/mock) to be on a safe side. E.g. I haven't spotted any `Endpoints` tests even though the API was broken with double-plural issue in `v4.1.3`.

