### PR TITLE
Allow parsing of version string with multi-digit parts

### DIFF
--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -133,7 +133,7 @@ public class ImageContent {
 	}
 
 	public String javaVersion() {
-		return shell.execute("java", "-version").getError().replaceAll("\n", "").replaceAll("openjdk version \"([0-9]\\.[0-9]\\.[0-9]).*", "$1");
+		return shell.execute("java", "-version").getError().replaceAll("\n", "").replaceAll("openjdk version \"([0-9]+\\.[0-9]+\\.[0-9]+).*", "$1");
 	}
 
 	public String mavenVersion() {
@@ -148,7 +148,7 @@ public class ImageContent {
 			mavenScriptInstalled = true;
 		}
 
-		return shell.executeWithBash(mavenScriptPath).getOutput().replaceAll("\n", "").replaceAll(".*Apache Maven ([0-9]\\.[0-9]\\.[0-9]) .*", "$1");
+		return shell.executeWithBash(mavenScriptPath).getOutput().replaceAll("\n", "").replaceAll(".*Apache Maven ([0-9]+\\.[0-9]+\\.[0-9]+) .*", "$1");
 	}
 
 	public List<RpmPackage> rpms() {


### PR DESCRIPTION
Current implementation isn't able to parse OpenJDK10+ version, eg. ```openjdk version "11.0.2" 2019-01-15```.
This PR fixes this for java version and also modifies maven version parsing the same way.