### PR TITLE
Add way to use token instead of username/password for admin.

### DIFF
--- a/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
@@ -3,6 +3,7 @@ package cz.xtf.core.config;
 public final class OpenShiftConfig {
 	public static final String OPENSHIFT_URL = "xtf.openshift.url";
 	public static final String OPENSHIFT_TOKEN = "xtf.openshift.token";
+	public static final String OPENSHIFT_ADMIN_TOKEN = "xtf.openshift.admin.token";
 	public static final String OPENSHIFT_VERSION = "xtf.openshift.version";
 	public static final String OPENSHIFT_NAMESPACE = "xtf.openshift.namespace";
 	public static final String OPENSHIFT_BINARY_PATH = "xtf.openshift.binary.path";
@@ -18,6 +19,10 @@ public final class OpenShiftConfig {
 
 	public static String token() {
 		return XTFConfig.get(OPENSHIFT_TOKEN);
+	}
+
+	public static String adminToken() {
+		return XTFConfig.get(OPENSHIFT_ADMIN_TOKEN);
 	}
 
 	public static String version() {

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
@@ -42,7 +42,11 @@ public class OpenShifts {
 	}
 
 	public static OpenShift admin(String namespace) {
-		return OpenShift.get(OpenShiftConfig.url(), namespace, OpenShiftConfig.adminUsername(), OpenShiftConfig.adminPassword());
+		if(OpenShiftConfig.adminToken() == null) {
+			return OpenShift.get(OpenShiftConfig.url(), namespace, OpenShiftConfig.adminUsername(), OpenShiftConfig.adminPassword());
+		} else {
+			return OpenShift.get(OpenShiftConfig.url(), namespace, OpenShiftConfig.adminToken());
+		}
 	}
 
 	public static OpenShift master() {


### PR DESCRIPTION
There is bug in openshift-client which does not allow currently to
connect with username to OCP 4.x https://github.com/fabric8io/kubernetes-client/issues/1505