### PR TITLE
Properties config feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target
 .idea/
 *.iml
 *.iws
+
+*.factorypath
+.vscode/

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ While framework itself doesn't require any configuration it can easy up some rep
 
 * System properties 
 * Environment variables
-* test.properties file in root of the project designed to contain user specific setup
-* global-test.properties file in root of the project designed to contain shared setup
+* `test.properties` file in root of the project designed to contain user specific setup. You can use `-Dxtf.test_properties.path` property to specify the location for the desired user specific setup.
+* `global-test.properties` file in root of the project designed to contain shared setup. You can use `-Dxtf.global_test_properties.path` property to specify the location for the desired user specific setup.
 
 The mapping between system properties and environment variables is done by lower casing environment variable, replacing `_` with `.` and adding `xtf.` before the result.
 

--- a/core/src/main/java/cz/xtf/core/config/XTFConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/XTFConfig.java
@@ -29,11 +29,13 @@ public final class XTFConfig {
 
 	private static final Properties properties = new Properties();
 
+	private static final String TEST_PROPERTIES_PATH = "xtf.test_properties.path";
+	private static final String GLOBAL_TEST_PROPERTIES_PATH = "xtf.global_test_properties.path";
+
 	// Pre-loading
 	static {
-		testPropertiesPath = XTFConfig.getProjectRoot().resolve("test.properties");
-		globalPropertiesPath = XTFConfig.getProjectRoot().resolve("global-test.properties");
-
+		globalPropertiesPath = resolvePropertiesPath(System.getProperty(GLOBAL_TEST_PROPERTIES_PATH, "global-test.properties"));
+		testPropertiesPath = resolvePropertiesPath(System.getProperty(TEST_PROPERTIES_PATH, "test.properties"));
 		properties.putAll(XTFConfig.getPropertiesFromPath(globalPropertiesPath));
 		properties.putAll(XTFConfig.getPropertiesFromPath(testPropertiesPath));
 		properties.putAll(System.getenv().entrySet().stream().collect(Collectors.toMap(e -> "xtf." + e.getKey().replaceAll("_", ".").toLowerCase(), Map.Entry::getValue)));
@@ -59,6 +61,13 @@ public final class XTFConfig {
 		Path dir = Paths.get("").toAbsolutePath();
 		while (dir.getParent().resolve("pom.xml").toFile().exists()) dir = dir.getParent();
 		return dir;
+	}
+
+	private static Path resolvePropertiesPath(String path) {
+		if (Paths.get(path).toFile().exists()) {
+			return Paths.get(path);
+		}
+		return getProjectRoot().resolve(path);
 	}
 
 	private static Properties getPropertiesFromPath(Path path) {


### PR DESCRIPTION
Added option to specify the `test.properties` and `global-test.properties` as a system property of `config.xtf.test.properties.path` and `config.xtf.global.test.properties.path`