### PR TITLE
Don't prepare build for skipped test class

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SinceVersionCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SinceVersionCondition.java
@@ -16,10 +16,10 @@ public class SinceVersionCondition implements ExecutionCondition {
 		SinceVersions sinceVersions = AnnotationSupport.findAnnotation(context.getElement(), SinceVersions.class).orElse(null);
 
 		if (sinceVersion != null) {
-			return this.resolve(sinceVersion);
+			return resolve(sinceVersion);
 		} else if (sinceVersions != null) {
 			for (SinceVersion sv : sinceVersions.value()) {
-				ConditionEvaluationResult cer = this.resolve(sv);
+				ConditionEvaluationResult cer = resolve(sv);
 				if (cer.isDisabled()) return cer;
 			}
 			return ConditionEvaluationResult.enabled("Feature is expected to be available.");
@@ -28,7 +28,7 @@ public class SinceVersionCondition implements ExecutionCondition {
 		return ConditionEvaluationResult.enabled("SinceVersion annotation isn't present on target.");
 	}
 
-	private ConditionEvaluationResult resolve(SinceVersion sinceVersion) {
+	public static ConditionEvaluationResult resolve(SinceVersion sinceVersion) {
 		Image image = Image.resolve(sinceVersion.image());
 		if (image.getRepo().equals(sinceVersion.name())) {
 			if (image.isVersionAtLeast(sinceVersion.since())) {

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
@@ -16,10 +16,10 @@ public class SkipForCondition implements ExecutionCondition {
 		SkipFors skipFors = AnnotationSupport.findAnnotation(context.getElement(), SkipFors.class).orElse(null);
 
 		if (skipFor != null) {
-			return this.resolve(skipFor);
+			return resolve(skipFor);
 		} else if (skipFors != null) {
 			for (SkipFor sf : skipFors.value()) {
-				ConditionEvaluationResult cer = this.resolve(sf);
+				ConditionEvaluationResult cer = resolve(sf);
 				if (cer.isDisabled()) return cer;
 			}
 			return  ConditionEvaluationResult.enabled("Feature is expected to be available.");
@@ -28,7 +28,7 @@ public class SkipForCondition implements ExecutionCondition {
 		return ConditionEvaluationResult.enabled("SkipFor(s) annotation isn't present on target.");
 	}
 
-	private ConditionEvaluationResult resolve(SkipFor skipFor) {
+	public static ConditionEvaluationResult resolve(SkipFor skipFor) {
 		Image image = Image.resolve(skipFor.image());
 		if (image.getRepo().equals(skipFor.name())) {
 			String reason = skipFor.reason().equals("") ? "" : " (" + skipFor.reason() + ")";


### PR DESCRIPTION
Little performance enhancement which prevents unnecessary builds from being prepared for test classes that are skipped as a whole. Both `@SkipFor` and `@SinceVersion` are taken into consideration.