### PR TITLE
[Test Helpers, Image, RHEL8] Adding Red Hat, Inc. (auxiliary key 2) GPG key

### DIFF
--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -28,6 +28,7 @@ public class ImageContent {
 	public static final String RED_HAT_RELEASE_KEY_2 = "199e2f91fd431d51";
 	public static final String RED_HAT_RELEASE_KEY_2_RPM = "gpg-pubkey-fd431d51-4ae0493b";
 	public static final String RED_HAT_AUXILIARY_KEY_RPM = "gpg-pubkey-2fa658e0-45700c69";
+	public static final String RED_HAT_AUXILIARY_KEY_2_RPM = "gpg-pubkey-d4082792-5b32db75";
 	public static final String[] DEFAULT_JAVA_UTILITIES = new String[]{"jjs", "keytool", "orbd", "rmid", "rmiregistry",
 			"servertool", "tnameserv", "unpack200", "javac", "appletviewer", "extcheck", "idlj", "jar", "jarsigner",
 			"javadoc", "javah", "javap", "jcmd", "jconsole", "jdb", "jdeps", "jhat", "jinfo", "jmap", "jps",


### PR DESCRIPTION
* Adding `Red Hat, Inc. (auxiliary key 2)` GPG key to `ImageContent` constants. This key is new backup key for RHEL8.
  
Please see [Product Signing Keys](https://access.redhat.com/security/team/key) for more information.