### PR TITLE
Add image stream waiters

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1,5 +1,24 @@
 package cz.xtf.core.openshift;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
 import cz.xtf.core.config.WaitingConfig;
 import cz.xtf.core.waiting.SimpleWaiter;
 import cz.xtf.core.waiting.Waiter;
@@ -35,6 +54,7 @@ import io.fabric8.openshift.api.model.BuildRequest;
 import io.fabric8.openshift.api.model.BuildRequestBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamTag;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.ProjectRequest;
 import io.fabric8.openshift.api.model.ProjectRequestBuilder;
@@ -46,26 +66,8 @@ import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.fabric8.openshift.client.ParameterValue;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import rx.Observable;
 import rx.observables.StringObservable;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class OpenShift extends DefaultOpenShiftClient {
@@ -265,6 +267,23 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public boolean deleteImageStream(ImageStream imageStream) {
 		return imageStreams().delete(imageStream);
+	}
+
+	// ImageStreamTags
+	public ImageStreamTag createImageStreamTag(ImageStreamTag imageStreamTag) {
+		return imageStreamTags().create(imageStreamTag);
+	}
+
+	public ImageStreamTag getImageStreamTag(String name) {
+		return imageStreamTags().withName(name).get();
+	}
+
+	public List<ImageStreamTag> getImageStreamTags() {
+		return imageStreamTags().list().getItems();
+	}
+
+	public boolean deleteImageStreamTag(ImageStreamTag imageStreamTag) {
+		return imageStreamTags().delete(imageStreamTag);
 	}
 
 	// Pods

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
@@ -14,6 +14,8 @@ import cz.xtf.core.waiting.SupplierWaiter;
 import cz.xtf.core.waiting.Waiter;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamTag;
 
 public class OpenShiftWaiters {
 	private OpenShift openShift;
@@ -50,6 +52,34 @@ public class OpenShiftWaiters {
 	public Waiter isLatestBuildPresent(String buildConfigName) {
 		Supplier<Build> supplier = () -> openShift.getLatestBuild(buildConfigName);
 		String reason = "Waiting for presence of latest build of buildconfig " + buildConfigName;
+
+		return new SupplierWaiter<>(supplier, Objects::nonNull, reason).logPoint(Waiter.LogPoint.BOTH).interval(5_000);
+	}
+
+	/**
+	 * Creates waiter for image stream presence with default timeout,
+	 * 5 seconds interval check and both logging points.
+	 *
+	 * @param imageStreamName name of image stream for which build to be waited upon
+	 * @return Waiter instance
+	 */
+	public Waiter isImageStreamPresent(String imageStreamName) {
+		Supplier<ImageStream> supplier = () -> openShift.getImageStream(imageStreamName);
+		String reason = "Waiting for presence of image stream " + imageStreamName;
+
+		return new SupplierWaiter<>(supplier, Objects::nonNull, reason).logPoint(Waiter.LogPoint.BOTH).interval(5_000);
+	}
+
+	/**
+	 * Creates waiter for image stream tag presence with default timeout,
+	 * 5 seconds interval check and both logging points.
+	 *
+	 * @param imageStreamTagName name of image stream tag for which to be waited upon
+	 * @return Waiter instance
+	 */
+	public Waiter isImageStreamTagPresent(String imageStreamTagName) {
+		Supplier<ImageStreamTag> supplier = () -> openShift.getImageStreamTag(imageStreamTagName);
+		String reason = "Waiting for presence of image stream tag " + imageStreamTagName;
 
 		return new SupplierWaiter<>(supplier, Objects::nonNull, reason).logPoint(Waiter.LogPoint.BOTH).interval(5_000);
 	}


### PR DESCRIPTION
In events I can see 26x `Error resolving ImageStreamTag jboss-eap72-openjdk11-openshift-rhel8:1.0 in namespace eap72-openjdk11-tests-suite-matrix`

```
2019-06-05T16:58:16Z	2019-06-05T16:49:52Z	26	managed-executor-service.15a55b7245955036	Event	null	Warning	BuildConfigInstantiateFailed	buildconfig-controller	error instantiating Build from BuildConfig eap72-openjdk11-tests-suite-matrix/managed-executor-service (0): Error resolving ImageStreamTag jboss-eap72-openjdk11-openshift-rhel8:1.0 in namespace eap72-openjdk11-tests-suite-matrix: unable to find latest tagged image
```

This is common error in testsuite events ~40x, but in most cases event occurs 7x or 8x. In this case event occur 26x and 10 minute timeout for build was not enough.

This pull request is attempt to prepare mechanism for wait for image streams presence. Does it make sense to you?
