### PR TITLE
Build Config timeout is configured independently. Unify to 2 minutes.

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BinaryBuild.java
+++ b/core/src/main/java/cz/xtf/core/bm/BinaryBuild.java
@@ -89,7 +89,7 @@ public abstract class BinaryBuild implements ManagedBuild {
 			ExecutorService executorService = Executors.newSingleThreadExecutor();
 			final Future<?> future = executorService.submit(() -> writeProjectTar(pos));
 
-			openShift.buildConfigs().withName(bc.getMetadata().getName()).instantiateBinary().fromInputStream(pis);
+			openShift.buildConfigs().withName(bc.getMetadata().getName()).instantiateBinary().withTimeoutInMillis(OpenShift.DEFAULT_TIMEOUT).fromInputStream(pis);
 			future.get();
 		} catch (IOException | InterruptedException | ExecutionException e) {
 			log.error("Exception building {}", id, e);

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -74,6 +74,8 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public static final String KEEP_LABEL = "xtf.cz/keep";
 
+	public static final int DEFAULT_TIMEOUT = 120_000;
+
 	/**
 	 * Autoconfigures the client with the default fabric8 client rules
 	 * @return
@@ -139,8 +141,8 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	private static void setupTimeouts(OpenShiftConfig config) {
 		config.setBuildTimeout(10 * 60 * 1000);
-		config.setRequestTimeout(120_000);
-		config.setConnectionTimeout(120_000);
+		config.setRequestTimeout(DEFAULT_TIMEOUT);
+		config.setConnectionTimeout(DEFAULT_TIMEOUT);
 	}
 
 	private final OpenShiftWaiters waiters;
@@ -581,7 +583,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 	}
 
 	public Build startBinaryBuild(String buildConfigName, File file) {
-		return buildConfigs().withName(buildConfigName).instantiateBinary().fromFile(file);
+		return buildConfigs().withName(buildConfigName).instantiateBinary().withTimeoutInMillis(DEFAULT_TIMEOUT).fromFile(file);
 	}
 
 	// BuildConfigs


### PR DESCRIPTION
Feature was introduced by https://github.com/fabric8io/kubernetes-client/pull/501.

Happened to us building pod was evicted because of DiskPresure for 15 sec. Default timeout seems to be 10 seconds. This change can help solve this cases.