### PR TITLE
[core] Enable CRs clean up with clean

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/crd/CustomResourceDefinitionContextProvider.java
+++ b/core/src/main/java/cz/xtf/core/openshift/crd/CustomResourceDefinitionContextProvider.java
@@ -1,0 +1,8 @@
+package cz.xtf.core.openshift.crd;
+
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+
+public interface CustomResourceDefinitionContextProvider {
+
+	CustomResourceDefinitionContext getContext();
+}


### PR DESCRIPTION
A way to hook custom resources into `clean` method. Solution for #293 

`RoleBindings` and `Roles` owned by ClusterServiceVersion shouldn't be deleted as those are created by `OLM` and in case of their deletion a chaos may arise.