### PR TITLE
Revert "[core] refactor OpenShift::clean to use Background policyDele…

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -75,7 +75,6 @@ public class OpenShift extends DefaultOpenShiftClient {
 	private static ServiceLoader<CustomResourceDefinitionContextProvider> crdContextProviderLoader;
 	private static String routeSuffix;
 
-	private static final String DEFAULT_PROPAGATION_POLICY = "Background";
 	public static final String KEEP_LABEL = "xtf.cz/keep";
 
 	/**
@@ -988,7 +987,12 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 		for (HasMetadata hasMetadata : listRemovableResources()) {
 			log.debug("DELETE :: " + hasMetadata.getKind() + "/" + hasMetadata.getMetadata().getName());
-			resource(hasMetadata).withPropagationPolicy(DEFAULT_PROPAGATION_POLICY).delete();
+			resource(hasMetadata).withGracePeriod(0).cascading(false).delete();
+		}
+		//TODO: Temporary workaround to delete any leftover resources with `cascading: true`
+		for (HasMetadata hasMetadata : listRemovableResources()) {
+			log.warn("DELETE LEFTOVER :: " + hasMetadata.getKind() + "/" + hasMetadata.getMetadata().getName());
+			resource(hasMetadata).withGracePeriod(0).cascading(true).delete();
 		}
 		return waiters.isProjectClean();
 	}


### PR DESCRIPTION
…gation"

This reverts commit caab6c69c04583a9c24b021aa5b02bc9266cdf44.

The newly added method for propagation policy is not setting any property on delete req. I'll open new issue in kubernetes-client repo.

Payload is still the same (controlled only by `cascading()`):
```
INFO: {"apiVersion":"v1","kind":"DeleteOptions","gracePeriodSeconds":0,"orphanDependents":false}
```
or
```
INFO: {"apiVersion":"v1","kind":"DeleteOptions","gracePeriodSeconds":0,"orphanDependents":true}
```

Cc @mchoma 