### PR TITLE
[testhelpers] ImageContent.listZipFilesInDir fix

### DIFF
--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -112,7 +112,7 @@ public class ImageContent {
 	}
 
 	public List<String> listZipFilesInDir(String path) {
-		return shell.executeWithBash("ls -R1 ~ " + path + " | grep '\\.zip$'").getOutputAsList();
+		return shell.executeWithBash("ls -R1 " + path + " | grep '\\.zip$'").getOutputAsList();
 	}
 
 	public List<String> listFilesMd5sumInDir(String path) {


### PR DESCRIPTION
* Fixing ImageContent.listZipFilesInDir(String path) listing files in home directory besides zips in specified directory.