### PR TITLE
[#308] Clean does not remove ReplicaSets

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1111,6 +1111,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 		List<HasMetadata> removables = new ArrayList<>();
 		removables.addAll(templates().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());
 		removables.addAll(apps().deployments().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());
+		removables.addAll(apps().replicaSets().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());
 		removables.addAll(batch().jobs().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());
 		removables.addAll(deploymentConfigs().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());
 		removables.addAll(apps().statefulSets().withLabelNotIn(OpenShift.KEEP_LABEL).list().getItems());


### PR DESCRIPTION
https://github.com/xtf-cz/xtf/issues/308#issuecomment-537833455

What I am not sure is order of cleaning ReplicaSet. Does someone see problem with putting it in front to `Deployments`, `DeploymentConfigs`, `StatefulSets`, `ReplicationControllers`? I believe this object belongs to this set.

Running localy testsuite with this change in place.