### PR TITLE
Add OpenShift::setupPullSecret + config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,23 @@ Example: `OPENSHIFT_MASTER_URL` is mapped to `xtf.openshift.master.url`.
 ##### Configuration:
 Take a look at [OpenShiftConfig](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java) class to see possible configurations. Enabling some them will allow you to instantiate as `OpenShift openShift = OpenShifts.master()`.
 
+##### Pull Secrets
+There's a convenient method `OpenShift::setupPullSecret()` to setup pull secrets as recommended by OpenShift [documentation](https://docs.openshift.com/container-platform/4.2/openshift_images/managing-images/using-image-pull-secrets.html).
+Property `xtf.openshift.pullsecret` is checked in `ProjectCreator` listener and `BuildManager` to populate projects with pull secret if provided. The pull secret is expected to be provided in Json format.
+
+Single registry
+```json
+{"auths":{"registry.redhat.io":{"auth":"<TOKEN>"}}}
+```
+
+Multiple registries
+```json
+{"auths":{"registry.redhat.io":{"auth":"<TOKEN>"},"quay.io":{"auth":"<TOKEN>"}}}
+```
+
+
 #### Waiters
-[Waiter](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/Waiter.java) is a concept for conditional waiting. It retrieves an object or state in specified `interval` and checks for the specified success and failure conditions. When one of them is met, the waiter will quit. If neither is met in `timeout`, then exception is thrown. 
+[Waiter](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/Waiter.java) is a concept for conditional waiting. It retrieves an object or state in specified `interval` and checks for the specified success and failure conditions. When one of them is met, the waiter will quit. If neither is met in `timeout`, then exception is thrown.
 
 XTF provides two different implementations ([SimpleWaiter](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/SimpleWaiter.java) and [SupplierWaiter](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/SupplierWaiter.java)) and several preconfigured instances. All the default parameters of preconfigured Waiters are overrideable.
 

--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -1,6 +1,7 @@
 package cz.xtf.core.bm;
 
 import cz.xtf.core.config.BuildManagerConfig;
+import cz.xtf.core.config.OpenShiftConfig;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.waiting.Waiter;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,10 @@ public class BuildManager {
 
 		if (openShift.getProject(openShift.getNamespace()) == null) {
 			openShift.createProjectRequest();
+			openShift.waiters().isProjectReady().waitFor();
+		}
+		if (OpenShiftConfig.pullSecret() != null) {
+			openShift.setupPullSecret(OpenShiftConfig.pullSecret());
 		}
 
 		openShift.addRoleToGroup("system:image-puller", "ClusterRole",  "system:authenticated");

--- a/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
@@ -15,6 +15,7 @@ public final class OpenShiftConfig {
 	public static final String OPENSHIFT_MASTER_KUBECONFIG = "xtf.openshift.master.kubeconfig";
 	public static final String OPENSHIFT_MASTER_TOKEN = "xtf.openshift.master.token";
 	public static final String OPENSHIFT_ROUTE_DOMAIN = "xtf.openshift.route_domain";
+	public static final String OPENSHIFT_PULL_SECRET = "xtf.openshift.pullsecret";
 
 	public static String url() {
 		return XTFConfig.get(OPENSHIFT_URL);
@@ -70,6 +71,10 @@ public final class OpenShiftConfig {
 
 	public static String masterKubeconfig() {
 		return XTFConfig.get(OPENSHIFT_MASTER_KUBECONFIG);
+	}
+
+	public static String pullSecret() {
+		return XTFConfig.get(OPENSHIFT_PULL_SECRET);
 	}
 
 	/**

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -13,14 +13,17 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.HorizontalPodAutoscaler;
 import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.rbac.Role;
@@ -63,6 +66,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -164,6 +168,36 @@ public class OpenShift extends DefaultOpenShiftClient {
 		super(openShiftConfig);
 
 		this.waiters = new OpenShiftWaiters(this);
+	}
+
+	public void setupPullSecret(String secret) {
+		setupPullSecret("xtf-pull-secret", secret);
+	}
+
+	/**
+	 * Convenient method to create pull secret for authenticated image registries.
+	 * The secret content must be provided in "dockerconfigjson" formar.
+	 *
+	 * E.g.: {"auths":{"registry.redhat.io":{"auth":"<REDACTED_TOKEN>"}}}
+	 *
+	 * Linking Secret to ServiceAccount is based on OpenShift documentation:
+	 * https://docs.openshift.com/container-platform/4.2/openshift_images/managing-images/using-image-pull-secrets.html
+	 *
+	 * @param name of the Secret to be created
+	 * @param secret content of Secret in json format
+	 */
+	public void setupPullSecret(String name, String secret) {
+		Secret pullSecret = new SecretBuilder()
+				.withNewMetadata()
+					.withNewName(name)
+					.addToLabels(KEEP_LABEL, "true")
+				.endMetadata()
+				.withNewType("kubernetes.io/dockerconfigjson")
+				.withData(Collections.singletonMap(".dockerconfigjson", Base64.getEncoder().encodeToString(secret.getBytes())))
+				.build();
+		secrets().createOrReplace(pullSecret);
+		serviceAccounts().withName("default").edit().addToImagePullSecrets(new LocalObjectReferenceBuilder().withName(pullSecret.getMetadata().getName()).build()).done();
+		serviceAccounts().withName("builder").edit().addToSecrets(new ObjectReferenceBuilder().withName(pullSecret.getMetadata().getName()).build()).done();
 	}
 
 	// General functions

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
@@ -71,6 +71,15 @@ public class OpenShiftWaiters {
 	}
 
 	/**
+	 * Create waiter for project to created with 20 seconds timeout.
+	 *
+	 * @return Waiter instance
+	 */
+	public Waiter isProjectReady() {
+		return new SimpleWaiter(() -> openShift.getProject() != null, TimeUnit.SECONDS, 20, "Waiting for the project to be created.");
+	}
+
+	/**
 	 * Creates waiter for clean project with 20 seconds timeout.
 	 *
 	 * @return Waiter instance

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -20,7 +20,7 @@ cz.xtf.junit5.listeners.TestResultReporter
 Records specified images url. Set `xtf.junit.used_image` property with images id split by ',' character. Particular image url will be then stored in `used-images.properties` file in project root.
 
 ##### ProjectCreator
-Creates project before test executions on OpenShift if doesn't exist. Use `xtf.junit.clean_openshift` property to delete after all test have been executed. 
+Creates project before test executions on OpenShift if doesn't exist. Use `xtf.junit.clean_openshift` property to delete after all test have been executed. It also checks property `xtf.openshift.pullsecret` to create pull secret in the new project.
 
 ##### TestExecutionLogger
 Logs individual test executions into the console.

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
@@ -1,5 +1,6 @@
 package cz.xtf.junit5.listeners;
 
+import cz.xtf.core.config.OpenShiftConfig;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.SimpleWaiter;
@@ -18,6 +19,10 @@ public class ProjectCreator implements TestExecutionListener {
 	public void testPlanExecutionStarted(TestPlan testPlan) {
 		if(openShift.getProject() == null) {
 			openShift.createProjectRequest();
+			openShift.waiters().isProjectReady().waitFor();
+		}
+		if(OpenShiftConfig.pullSecret() != null) {
+			openShift.setupPullSecret(OpenShiftConfig.pullSecret());
 		}
 	}
 


### PR DESCRIPTION
Resolves #283 

This PR adds support for pull secret in json format and mimics the openshift-install `pullSecret` parameter. It's quiet extensible to add additional registries e.g. quay, dockerhub there's no need to change the impl.

Please review and let me know if that's sufficient solution. I've tested it with in namespace deployment and with `BuildManager` successfully.

Format:
```json
{"auths":{"registry.redhat.io":{"auth":"<REDACTED_TOKEN>"}}}
```