### PR TITLE
Upgrade to 4.7.0 openshift client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
 		<!-- Depedency version properties -->
 		<version.httpclient>4.5.5</version.httpclient>
-		<version.openshift-client>4.6.1</version.openshift-client>
+		<version.openshift-client>4.7.0</version.openshift-client>
 		<version.commons-io>2.6</version.commons-io>
 		<version.commons-lang3>3.4</version.commons-lang3>
 		<version.commons-compress>1.19</version.commons-compress>


### PR DESCRIPTION
Release notes
https://github.com/fabric8io/kubernetes-client/releases/tag/v4.7.0

Containing fix for
https://github.com/fabric8io/kubernetes-client/issues/1850

Preliminary testing with xtf containing 4.7.0 openshift client revealed no obvious problem.