### PR TITLE
Upgrade openshift-client to avoid issues with openshift 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
 		<!-- Depedency version properties -->
 		<version.httpclient>4.5.5</version.httpclient>
-		<version.openshift-client>4.6.1</version.openshift-client>
+		<version.openshift-client>4.7.1</version.openshift-client>
 		<version.commons-io>2.6</version.commons-io>
 		<version.commons-lang3>3.4</version.commons-lang3>
 		<version.commons-compress>1.19</version.commons-compress>


### PR DESCRIPTION
# Summary
I had the next issue when using this framework to connect with Openshift V4.3:

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://api.xxxx/oapi/v1/namespaces/myproject/templates. Received status: Status(apiVersion=v1, code=404, details=null, kind=Status, message=null, metadata=null, reason=null, status=null, additionalProperties={}).
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.requestFailure(OperationSupport.java:510)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.assertResponseCode(OperationSupport.java:449)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:413)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleResponse(OperationSupport.java:372)
	at io.fabric8.kubernetes.client.dsl.base.OperationSupport.handleCreate(OperationSupport.java:241)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.handleCreate(BaseOperation.java:819)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:334)
	at io.fabric8.kubernetes.client.dsl.base.BaseOperation.create(BaseOperation.java:330)
	at cz.xtf.core.openshift.OpenShift.createTemplate(OpenShift.java:1027)
```

However, with an Openshift V3 instance, it had been working fine so far. 

## Fix

It seems Fabric8 fixed this issue in their end and using the version 4.7.1 made it worked with no more required changes.
I confirmed that it's working fine for me now when using Openshift v3 and v4.3. [Here](https://github.com/fabric8io/kubernetes-client), we can see the compatibility with Openshift and Fabric8 versions, but no mention to Openshift v4.3 though. 

There is another PR that requires the same fix: https://github.com/xtf-cz/xtf/pull/332