### PR TITLE
read cluster version as admin

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
@@ -187,7 +187,7 @@ public class OpenShifts {
 					systemType = "linux";
 					ocFileName = "oc.tar";
 				}
-				final Optional<Route> downloadsRouteOptional = Optional.ofNullable(master("openshift-console").getRoute("downloads"));
+				final Optional<Route> downloadsRouteOptional = Optional.ofNullable(admin("openshift-console").getRoute("downloads"));
 				final Route downloads = downloadsRouteOptional.orElseThrow(() -> new IllegalStateException("We are not able to find download link for OC binary."));
 				clientLocation = String.format("https://" + downloads.getSpec().getHost() + "/amd64/%s/", systemType);
 				return downloadOpenShiftBinaryInternal(version, ocFileName, clientLocation, true);
@@ -240,7 +240,7 @@ public class OpenShifts {
 					.withScope("NonNamespaced")
 					.withVersion("v1")
 					.build();
-			return toString(toMap(toMap(master().customResource(crdContext).get("version"), "status"), "desired"), "version");
+			return toString(toMap(toMap(admin().customResource(crdContext).get("version"), "status"), "desired"), "version");
 		}
 	}
 


### PR DESCRIPTION
By default "master" user cannot read routes and cluster version, so "admin" user needs to be used. 

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://api.eapqe-004-wgcy.dynamic.xpaas:6443/apis/config.openshift.io/v1/clusterversions/version. Message: clusterversions.config.openshift.io "version" is forbidden: User "xpaasqe" cannot get resource "clusterversions" in API group "config.openshift.io" at the cluster scope.
```

Please make sure your PR meets the following requirements:
- [X] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [X] Code is formatted, imports ordered, code compiles and tests are passing
- [X] Code is self-descriptive and/or documented
