### PR TITLE
[PodShell] Add ability to execute cmd in pod with more containers

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1110,6 +1110,10 @@ public class OpenShift extends DefaultOpenShiftClient {
 		return new PodShell(this, pod);
 	}
 
+	public PodShell podShell(Pod pod, String containerName) {
+		return new PodShell(this, pod, containerName);
+	}
+
 	// Clean up function
 	/**
 	 * Deletes all* resources in namespace. Doesn't wait till all are deleted. <br/>


### PR DESCRIPTION
When executing commands in pod, in case there are multiple containers in the pod, the execution fails with:

```
io.fabric8.kubernetes.client.KubernetesClientException: a container name must be specified for pod <pod>, choose one of: [<container1> <container2>]
	at io.fabric8.kubernetes.client.dsl.internal.ExecWebSocketListener.onFailure(ExecWebSocketListener.java:237)
	at okhttp3.internal.ws.RealWebSocket.failWebSocket(RealWebSocket.java:571)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:198)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: java.lang.Throwable: waiting here
		at io.fabric8.kubernetes.client.utils.Utils.waitUntilReady(Utils.java:135)
		at io.fabric8.kubernetes.client.dsl.internal.ExecWebSocketListener.waitUntilReady(ExecWebSocketListener.java:188)
		at io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl.exec(PodOperationsImpl.java:301)
		at io.fabric8.kubernetes.client.dsl.internal.PodOperationsImpl.exec(PodOperationsImpl.java:72)
		at cz.xtf.core.openshift.PodShell.execute(PodShell.java:45)
```

Adds a new podShell constructor with pod & container name

Please make sure your PR meets the following requirements:
- [X] Pull Request contains a description of the changes
- [X] Pull Request does not include fixes for multiple issues/topics
- [X] Code is formatted, imports ordered, code compiles and tests are passing
- [X] Code is self-descriptive and/or documented
