### PR TITLE
WIP - Allow use of patterns in @SkipFor and @SinceVersion annotations in "n…

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/annotations/SinceVersion.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/SinceVersion.java
@@ -15,6 +15,9 @@ import java.lang.annotation.Target;
 @ExtendWith(SinceVersionCondition.class)
 public @interface SinceVersion {
 
+	/**
+	 * Name or regexp pattern matching name of the image. For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*"
+	 */
 	String name();
 
 	String image();

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
@@ -15,6 +15,9 @@ import java.lang.annotation.Target;
 @ExtendWith(SkipForCondition.class)
 public @interface SkipFor {
 
+	/**
+	 * Name or regexp pattern matching name of the image. For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*"
+	 */
 	String name();
 
 	String image();

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SinceVersionCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SinceVersionCondition.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
+import java.util.regex.Pattern;
+
 public class SinceVersionCondition implements ExecutionCondition {
 
 	@Override
@@ -30,7 +32,8 @@ public class SinceVersionCondition implements ExecutionCondition {
 
 	public static ConditionEvaluationResult resolve(SinceVersion sinceVersion) {
 		Image image = Image.resolve(sinceVersion.image());
-		if (image.getRepo().equals(sinceVersion.name())) {
+		Pattern name = Pattern.compile(sinceVersion.name());
+		if (name.matcher(image.getRepo()).matches()) {
 			if (image.isVersionAtLeast(sinceVersion.since())) {
 				return ConditionEvaluationResult.enabled("'" + image.getRepo() + "' image tag is equal or bigger then expected. Tested feature should be available.");
 			} else {

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
+import java.util.regex.Pattern;
+
 public class SkipForCondition implements ExecutionCondition {
 
 	@Override
@@ -30,7 +32,8 @@ public class SkipForCondition implements ExecutionCondition {
 
 	public static ConditionEvaluationResult resolve(SkipFor skipFor) {
 		Image image = Image.resolve(skipFor.image());
-		if (image.getRepo().equals(skipFor.name())) {
+		Pattern name = Pattern.compile(skipFor.name());
+		if (name.matcher(image.getRepo()).matches()) {
 			String reason = skipFor.reason().equals("") ? "" : " (" + skipFor.reason() + ")";
 			return ConditionEvaluationResult.disabled("Tested feature isn't expected to be available in '" + image.getRepo() + "' image." + reason);
 		} else {


### PR DESCRIPTION
…ame"

Currently @SkipFor and @SinceVersion does not allow to use patterns for `name` of the image. This PR is adding this support. 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
