### PR TITLE
WIP: Adding support for tracing imagestreams creation

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/client/dsl/TracedImageStreamOperations.java
+++ b/core/src/main/java/cz/xtf/core/openshift/client/dsl/TracedImageStreamOperations.java
@@ -1,0 +1,79 @@
+package cz.xtf.core.openshift.client.dsl;
+
+import cz.xtf.core.openshift.imagestreams.MapBasedImageStreamRegistry;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.base.OperationContext;
+import io.fabric8.openshift.api.model.DoneableImageStream;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamList;
+import io.fabric8.openshift.client.OpenShiftConfig;
+import io.fabric8.openshift.client.dsl.internal.OpenShiftOperation;
+import okhttp3.OkHttpClient;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Represents a concrete implementation of {@link OpenShiftOperation} to handle 
+ * operations on {@link ImageStream} instances.
+ * 
+ * This class replaces {@link ImageStreamOperationsImpl} to add the logic 
+ * needed to leverage the {@link MapBasedImageStreamRegistry} in order to 
+ * keep track of image streams creation.
+ */
+@Slf4j
+public class TracedImageStreamOperations 
+	extends OpenShiftOperation<ImageStream, ImageStreamList, DoneableImageStream, Resource<ImageStream, DoneableImageStream>> {
+
+	public TracedImageStreamOperations(OkHttpClient client, OpenShiftConfig config) {
+		this(new OperationContext().withOkhttpClient(client).withConfig(config));
+	}
+
+	public TracedImageStreamOperations(OperationContext context) {
+		super(context.withApiGroupName("image.openshift.io")
+				.withApiGroupVersion("v1")
+				.withPlural("imagestreams"));
+		this.type = ImageStream.class;
+		this.listType = ImageStreamList.class;
+		this.doneableType = DoneableImageStream.class;
+	}
+
+	@Override
+	public TracedImageStreamOperations newInstance(OperationContext context) {
+		TracedImageStreamOperations result = new TracedImageStreamOperations(context);
+		return result;
+	}
+
+	@Override
+	protected ImageStream handleCreate(ImageStream resource) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+		log.debug(String.format("Handling creation of image stream resource %s in namespace %s.",
+			resource.getMetadata().getName(),
+			this.getNamespace())
+		);
+		return MapBasedImageStreamRegistry.get().register(resource, i -> {
+			try {
+				return super.handleCreate(resource);
+			} catch (ExecutionException | InterruptedException | IOException e) {
+				throw KubernetesClientException.launderThrowable(forOperationType("create"), e);
+			}
+		});
+	}
+
+	@Override
+	protected void handleDelete(URL requestUrl, long gracePeriodSeconds, String propagationPolicy, boolean cascading) throws ExecutionException, InterruptedException, KubernetesClientException, IOException {
+		log.debug(String.format("Handling deletion of image stream resource at %s.",
+			requestUrl)
+		);
+		MapBasedImageStreamRegistry.get().unregister(this.getName(), i -> {
+			try {
+				super.handleDelete(requestUrl, gracePeriodSeconds, propagationPolicy, cascading);
+			} catch (ExecutionException | InterruptedException | IOException e) {
+				throw KubernetesClientException.launderThrowable(forOperationType("delete"), e);
+			}
+		});
+		
+	}
+}

--- a/core/src/main/java/cz/xtf/core/openshift/imagestreams/ImageStreamHolder.java
+++ b/core/src/main/java/cz/xtf/core/openshift/imagestreams/ImageStreamHolder.java
@@ -1,0 +1,49 @@
+package cz.xtf.core.openshift.imagestreams;
+
+import io.fabric8.openshift.api.model.ImageStream;
+
+/**
+ * An image stream with its related subscriptions
+ */
+class ImageStreamHolder {
+	private final ImageStream imageStream;
+	private int subscriptions;
+	
+	private ImageStreamHolder(final ImageStream subscribedImageStream, final int initialSubscriptions) {
+		this.imageStream = subscribedImageStream;
+		this.subscriptions = initialSubscriptions;
+	}
+	
+	ImageStreamHolder subscribe() {
+		this.subscriptions += 1;
+		return this;
+	}
+	
+	ImageStreamHolder unsubscribe() {
+		this.subscriptions -= 1;
+		return this;
+	}
+	
+	ImageStream get() {
+		return imageStream;
+	}
+	
+	int count() {
+		return subscriptions;
+	}
+	
+	static final class Builder {
+		private ImageStream imageStream;
+
+		Builder() {}
+
+		Builder withImageStream(final ImageStream imageStream) {
+			this.imageStream = imageStream;
+			return this;
+		}
+
+		ImageStreamHolder build() {
+			return new ImageStreamHolder(imageStream, 1);
+		}
+	}
+}

--- a/core/src/main/java/cz/xtf/core/openshift/imagestreams/ImageStreamRegistry.java
+++ b/core/src/main/java/cz/xtf/core/openshift/imagestreams/ImageStreamRegistry.java
@@ -1,0 +1,16 @@
+package cz.xtf.core.openshift.imagestreams;
+
+import io.fabric8.openshift.api.model.ImageStream;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+/**
+ * Defines the contract for implementing a registry which keeps track
+ * of {@link ImageStream} instances.
+ */
+public interface ImageStreamRegistry {
+
+	ImageStream register(ImageStream imageStream, UnaryOperator<ImageStream> imageStreamCreation);
+
+	ImageStream unregister(String name, Consumer<ImageStream> imageStreamDeletion);
+}

--- a/core/src/main/java/cz/xtf/core/openshift/imagestreams/MapBasedImageStreamRegistry.java
+++ b/core/src/main/java/cz/xtf/core/openshift/imagestreams/MapBasedImageStreamRegistry.java
@@ -1,0 +1,112 @@
+package cz.xtf.core.openshift.imagestreams;
+
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
+import io.fabric8.openshift.api.model.ImageStream;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Represents a map based registry for keeping track of {@link ImageStream} 
+ * instances.
+ * 
+ * When an image stream passed in to be cached via the 
+ * {@link MapBasedImageStreamRegistry#register(io.fabric8.openshift.api.model.ImageStream, java.util.function.UnaryOperator)} method
+ * the registry checks whether an instance with the same key has been cached 
+ * in order to avoid errors due to the attempt of creating two identical
+ * image streams for the same namespace.
+ */
+@Slf4j
+public class MapBasedImageStreamRegistry implements ImageStreamRegistry {
+
+	private static MapBasedImageStreamRegistry instance;
+	private final OpenShift openShift;
+	private final ConcurrentHashMap<String, ImageStreamHolder> internalCache = new ConcurrentHashMap<>();
+
+	private MapBasedImageStreamRegistry(OpenShift openShift) {
+		this.openShift = openShift;
+	}
+
+	private String forgeKey(ImageStream imageStream) {
+		return forgeKey(imageStream.getMetadata().getName());
+	}
+
+	private String forgeKey(String imageStreamName) {
+		return String.format("namespace=%s;name=%s", openShift.getNamespace(), imageStreamName);
+	}
+
+	//	singleton here
+	public static MapBasedImageStreamRegistry get() {
+		if (instance == null) {
+			synchronized (MapBasedImageStreamRegistry.class) {
+				if (instance == null) {
+					instance = new MapBasedImageStreamRegistry(OpenShifts.master());
+					//  let's initialize the cache with survivors
+					log.debug("About to initialize image streams cache with survivors");
+					instance.openShift.imageStreams().list().getItems().stream().forEach(is -> 
+						instance.internalCache.put(
+							instance.forgeKey(is), 
+							new ImageStreamHolder.Builder().withImageStream(is).build()
+						)
+					);					
+					log.debug(String.format("Chache was filled in with survivors and is now storing %d items", 
+						instance.internalCache.size())
+					);
+				}
+			}
+		}
+		return instance;
+	}
+
+	@Override
+	public ImageStream register(ImageStream imageStream, UnaryOperator<ImageStream> imageStreamCreationFunc) {
+		String key = forgeKey(imageStream);
+		log.debug(String.format("About to evaluate caching %s image stream with key: %s. Chache is currently storing %d items", 
+			imageStream.getMetadata().getName(), 
+			key, 
+			internalCache.size())
+		);
+		ImageStream item;
+		synchronized(MapBasedImageStreamRegistry.class) {
+			ImageStreamHolder existing = internalCache.get(key);
+			if (existing != null) {
+				existing.subscribe();
+			} else {
+				existing = new ImageStreamHolder.Builder().withImageStream(imageStreamCreationFunc.apply(imageStream)).build();
+				existing = internalCache.put(key, existing);
+			}
+			item = existing.get();
+		}
+		log.debug(String.format("Compute completed. Chache is now storing %d items", 
+			internalCache.size())
+		);
+		return item;
+	}
+
+	@Override
+	public ImageStream unregister(String name, Consumer<ImageStream> imageStreamDeletion) {
+		String key = forgeKey(name);
+		log.debug(String.format("About to remove %s image stream with key: %s. Chache is currently storing %d items", 
+			name, 
+			key, 
+			internalCache.size())
+		);
+		ImageStream item;
+		synchronized(MapBasedImageStreamRegistry.class) {
+			ImageStreamHolder existing = internalCache.get(key);
+			item = existing.get();
+			if (existing.count() == 1) {
+				imageStreamDeletion.accept(item);
+				internalCache.remove(key);
+			} else {
+				existing.unsubscribe();
+			}			
+		}
+		log.debug(String.format("Removal completed. Chache is now storing %d items", 
+			internalCache.size())
+		);
+		return item;
+	}
+}


### PR DESCRIPTION
This PR is to add a new class for image streams operations in order to keep track of those created through a `ConcurrentHashMap` that would serve as a cache.
This is to avoid errors when requesting for the creation of an image stream that already exists in the namespace.

The PR is WIP because there seem to be a specific case that should still be managed: when the image stream creation is requested by some internal operation (e.g.: some operator code) the newly introduced cache wouldn't be aware of it, becoming unreliable.

@istraka I'd like to assign this PR review to you but it seems I am not able to do that.
CC @mnovak1 
 
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
