### PR TITLE
Allow use of Docker image metadata in @SkipFor and @SinceVersion annotations in 'name'

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
+++ b/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
@@ -1,0 +1,70 @@
+package cz.xtf.junit5.model;
+
+import cz.xtf.core.image.Image;
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.waiting.SimpleWaiter;
+import cz.xtf.core.waiting.Waiter;
+import io.fabric8.openshift.api.model.ImageStreamTag;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Represents Docker image metadata by exposing convenience methods to access 
+ * them and provides a cache to optimize retrievals.
+ */
+public class DockerImageMetadata {
+	private static final String METADATA_CONFIG = "Config";
+	private static final String METADATA_CONFIG_LABELS = "Labels";
+	private static final String METADATA_CONFIG_LABEL_NAME = "name";
+	private static final ConcurrentHashMap<String, DockerImageMetadata> CACHED_METADATA = new ConcurrentHashMap<>();
+	
+	private final Map<String, Object> metadata;
+
+	private DockerImageMetadata(Map<String, Object> metadata) {
+		this.metadata = metadata;
+	}
+	
+	private static String forgeMetadataKey(OpenShift openshift, Image image) {
+		return String.format("%s;%s", openshift.getNamespace(), image.getUrl());
+	}
+
+	public static DockerImageMetadata prepare(OpenShift openShift, String imageUrl) {
+		return DockerImageMetadata.prepare(openShift, Image.from(imageUrl));
+	}
+
+	public static DockerImageMetadata prepare(OpenShift openShift, Image image) {
+		openShift.createImageStream(image.getImageStream());
+
+		Supplier<ImageStreamTag> imageStreamTagSupplier = () -> openShift.imageStreamTags().withName(image.getRepo() + ":" + image.getMajorTag()).get();
+		Waiter metadataWaiter = new SimpleWaiter(() -> {
+			ImageStreamTag isTag = imageStreamTagSupplier.get();
+			if (isTag != null && isTag.getImage() != null && isTag.getImage().getDockerImageMetadata() != null && isTag.getImage().getDockerImageMetadata().getAdditionalProperties() != null) {
+				return true;
+			}
+			return false;
+		}, "Giving OpenShift instance time to download image metadata.");
+
+		metadataWaiter.waitFor();
+		
+		return CACHED_METADATA.computeIfAbsent(forgeMetadataKey(openShift, image), m -> new DockerImageMetadata(imageStreamTagSupplier.get().getImage().getDockerImageMetadata().getAdditionalProperties()));
+	}
+	
+	private Map<String, Object> getConfig() {
+		return (Map<String, Object>)metadata.get(METADATA_CONFIG);
+	}
+	
+	private Map<String, Object> getLabels() {
+		return (Map<String, Object>)getConfig().get(METADATA_CONFIG_LABELS);
+	}
+	
+	private String getLabelValue(String label) {
+		return (String)getLabels().get(label);
+	}
+	
+	public String getNameLabelValue() {
+		return getLabelValue(METADATA_CONFIG_LABEL_NAME);
+	}
+	
+	//  ... add more of them as needed...
+}


### PR DESCRIPTION
This PR introduces a new class, namely `DockerImageMetadata` in `Junit5` module.
The class is performs to retrieval and caching of Docker image metadata and exposes them with convenience methods that are then used by the `@SkipFor` annotation - see `SkipForCondition` class - in order to selectively disable tests based on the image name. 
This is an alternative solution to the existing implementation which relies on regex.

The changes introduced by this PR are actually depending on https://github.com/xtf-cz/xtf/pull/357 because the image metadata retrievakl ends up in calling `OpenShift.createImageStream()` which would fail in case the requested image is already present in the given namespace.

@istraka I'd like to assign this PR review to you.
CC @simkam, @mchoma, @mnovak1.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
