### PR TITLE
Provide robust solution for recognizing image name for SkipFor logic

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -41,6 +41,7 @@ import io.fabric8.openshift.api.model.BuildRequest;
 import io.fabric8.openshift.api.model.BuildRequestBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamTag;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.ProjectRequest;
 import io.fabric8.openshift.api.model.ProjectRequestBuilder;
@@ -318,6 +319,23 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public boolean deleteImageStream(ImageStream imageStream) {
 		return imageStreams().delete(imageStream);
+	}
+
+	// ImageStreamsTags
+	public ImageStreamTag createImageStreamTag(ImageStreamTag imageStreamTag) {
+		return imageStreamTags().create(imageStreamTag);
+	}
+
+	public ImageStreamTag getImageStreamTag(String imageStreamName, String tag) {
+		return imageStreamTags().withName(imageStreamName + ":" + tag).get();
+	}
+
+	public List<ImageStreamTag> getImageStreamTags() {
+		return imageStreamTags().list().getItems();
+	}
+
+	public boolean deleteImageStreamTag(ImageStreamTag imageStreamTag) {
+		return imageStreamTags().delete(imageStreamTag);
 	}
 
 	// Pods

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/SinceVersion.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/SinceVersion.java
@@ -15,10 +15,21 @@ import java.lang.annotation.Target;
 @ExtendWith(SinceVersionCondition.class)
 public @interface SinceVersion {
 
+
 	/**
 	 * Name or regexp pattern matching name of the image. For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*"
+	 * <p>
+	 * Only one of {@code imageMetadataLabelName} and {@code name} can be presented.
 	 */
-	String name();
+	String name() default "";
+
+	/**
+	 * Name or regexp pattern matching name in {@code Docker Labels} in image metadata
+	 * For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*".
+	 * <p>
+	 * Only one of {@code imageMetadataLabelName} and {@code name} can be presented.
+	 */
+	String imageMetadataLabelName() default "";
 
 	String image();
 

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
@@ -17,8 +17,18 @@ public @interface SkipFor {
 
 	/**
 	 * Name or regexp pattern matching name of the image. For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*"
+	 * <p>
+	 * Only one of {@code imageMetadataLabelName} and {@code name} can be presented.
 	 */
-	String name();
+	String name() default "";
+
+	/**
+	 * Name or regexp pattern matching name in {@code Docker Labels} in image metadata
+	 * For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*".
+	 * <p>
+	 * Only one of {@code imageMetadataLabelName} and {@code name} can be presented.
+	 */
+	String imageMetadataLabelName() default "";
 
 	String image();
 

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
@@ -1,17 +1,19 @@
 package cz.xtf.junit5.extensions;
 
 import cz.xtf.core.image.Image;
+import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.junit5.annotations.SkipFor;
 import cz.xtf.junit5.annotations.SkipFors;
+import cz.xtf.junit5.model.DockerImageMetadata;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SkipForCondition implements ExecutionCondition {
-
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
 		SkipFor skipFor = AnnotationSupport.findAnnotation(context.getElement(), SkipFor.class).orElse(null);
@@ -31,9 +33,20 @@ public class SkipForCondition implements ExecutionCondition {
 	}
 
 	public static ConditionEvaluationResult resolve(SkipFor skipFor) {
+		if (skipFor.name().equals("") == skipFor.imageMetadataLabelName().equals("")) {
+			throw new RuntimeException("Only one of 'name' and 'imageMetadataLabelName' can be presented in 'SkipFor' annotation.");
+		}
 		Image image = Image.resolve(skipFor.image());
-		Pattern name = Pattern.compile(skipFor.name());
-		if (name.matcher(image.getRepo()).matches()) {
+		Matcher matcher;
+
+		if (!skipFor.name().equals("")) {
+			matcher = Pattern.compile(skipFor.name()).matcher(image.getRepo());
+		} else {
+			DockerImageMetadata metadata = DockerImageMetadata.get(OpenShifts.master(), image);
+			matcher = Pattern.compile(skipFor.imageMetadataLabelName()).matcher(metadata.labels().get("name"));
+		}
+
+		if (matcher.matches()) {
 			String reason = skipFor.reason().equals("") ? "" : " (" + skipFor.reason() + ")";
 			return ConditionEvaluationResult.disabled("Tested feature isn't expected to be available in '" + image.getRepo() + "' image." + reason);
 		} else {

--- a/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
+++ b/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
@@ -1,0 +1,164 @@
+package cz.xtf.junit5.model;
+
+import cz.xtf.core.image.Image;
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.waiting.SimpleWaiter;
+import cz.xtf.core.waiting.Waiter;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.ImageStreamTag;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Represents Docker image metadata by exposing convenience methods to access
+ * them and provides a cache to optimize retrievals.
+ */
+public class DockerImageMetadata {
+	private static final String METADATA_CONFIG = "Config";
+	private static final String METADATA_CONFIG_LABELS = "Labels";
+	private static final String METADATA_CONFIG_ENV = "Env";
+	private static final String METADATA_CONFIG_CMD = "Cmd";
+	private static final String METADATA_CONFIG_EXPOSED_PORTS = "ExposedPorts";
+
+	private static final ConcurrentHashMap<String, DockerImageMetadata> CACHED_METADATA = new ConcurrentHashMap<>();
+
+	private final Map<String, Object> metadata;
+
+	private DockerImageMetadata(Map<String, Object> metadata) {
+		this.metadata = metadata;
+	}
+
+	private static String forgeMetadataKey(OpenShift openshift, Image image) {
+		return String.format("%s;%s", openshift.getNamespace(), image.getUrl());
+	}
+
+	/**
+	 * Get docker image metadata for image in openshift namespace. Metadata are cached.
+	 */
+	public static DockerImageMetadata get(OpenShift openShift, String imageUrl) {
+		return get(openShift, Image.from(imageUrl));
+	}
+
+	/**
+	 * Get docker image metadata for image in openshift namespace. Metadata are cached.
+	 */
+	public static DockerImageMetadata get(OpenShift openShift, Image image) {
+		return CACHED_METADATA.computeIfAbsent(forgeMetadataKey(openShift, image), s -> getMetadata(openShift, image));
+	}
+
+	/**
+	 * <ul>
+	 *     <ol>try to find existing image in tag list and return docker image metadata from it</ol>
+	 *     <ol>create new image stream of unique name, gather metadata and delete the stream</ol>
+	 * </ul>
+	 */
+	private static DockerImageMetadata getMetadata(OpenShift openShift, Image image) {
+		// try to find existing one
+		ImageStreamTag imageStreamTag = openShift.getImageStreamTag(image.getRepo(), image.getMajorTag());
+		DockerImageMetadata metadataFromTag = getMetadataFromTag(imageStreamTag);
+		if (metadataFromTag != null) {
+			return metadataFromTag;
+		}
+
+		// create new one of unique name
+		String tempName = image.getRepo() + "-" + randomString();
+		ImageStream imageStream = image.getImageStream(tempName);
+		imageStream.getMetadata().setName(tempName);
+		openShift.imageStreams().createOrReplace(imageStream);
+
+		// wait till metadata are available
+		Waiter metadataWaiter = new SimpleWaiter(() -> DockerImageMetadata.areMetadataForImageReady(openShift.getImageStreamTag(tempName, image.getMajorTag())),
+				"Giving OpenShift instance time to download image metadata.");
+		boolean metadataOK = metadataWaiter.waitFor();
+
+		// delete unique image stream and return metadata
+		DockerImageMetadata metadata = metadataOK ? getMetadataFromTag(openShift.getImageStreamTag(tempName, image.getMajorTag())) : null;
+		openShift.deleteImageStream(imageStream);
+		return metadata;
+	}
+
+	private static DockerImageMetadata getMetadataFromTag(ImageStreamTag imageStreamTag) {
+		return areMetadataForImageReady(imageStreamTag) ? new DockerImageMetadata(imageStreamTag.getImage().getDockerImageMetadata().getAdditionalProperties()) : null;
+	}
+
+	private static boolean areMetadataForImageReady(ImageStreamTag tag) {
+		return tag != null && tag.getImage() != null && tag.getImage().getDockerImageMetadata() != null && tag.getImage().getDockerImageMetadata().getAdditionalProperties() != null;
+	}
+
+	private static String randomString() {
+		return new Random().ints('a', 'z' + 1)
+				.limit(5)
+				.collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+				.toString();
+	}
+
+	private Map<String, Object> getConfig() {
+		return (Map<String, Object>) metadata.get(METADATA_CONFIG);
+	}
+
+	/**
+	 * Returns image labels of Config/Labels path
+	 *
+	 * @return map of labels
+	 */
+	public Map<String, String> labels() {
+		return (Map<String, String>) getConfig().get(METADATA_CONFIG_LABELS);
+	}
+
+	/**
+	 * Returns image environments of Config/Env path
+	 *
+	 * @return map of environment variables
+	 */
+	public Map<String, String> envs() {
+		final Map<String, String> envMap = new HashMap<>();
+
+		List<String> envList = (List<String>) getConfig().get(METADATA_CONFIG_ENV);
+		envList.forEach(
+				node -> {
+					String[] keyValue = node.split("=", 2);
+					envMap.put(keyValue[0], keyValue[1]);
+				}
+		);
+		return Collections.unmodifiableMap(envMap);
+	}
+
+	/**
+	 * Returns default container command on Config/Cmd path
+	 *
+	 * @return default command
+	 */
+	public String command() {
+		List<String> cmdList = (List<String>) getConfig().get(METADATA_CONFIG_CMD);
+		return cmdList.get(0);
+	}
+
+
+	/**
+	 * Returns integer set of exposed ports by specified protocol (eg. tcp, udp) on Config/ExposedPorts path.
+	 *
+	 * @return port set
+	 */
+	public Set<Integer> exposedPorts(String protocol) {
+		final Set<Integer> result = new HashSet<>();
+		final Map<String, Object> exposedPorts = (Map<String, Object>) getConfig().get(METADATA_CONFIG_EXPOSED_PORTS);
+		exposedPorts.keySet().forEach(
+				portDef -> {
+					final String[] split = portDef.split("/");
+					if (StringUtils.isBlank(protocol) || split[1].equalsIgnoreCase(protocol)) {
+						result.add(Integer.parseInt(split[0]));
+					}
+				}
+		);
+
+		return result;
+	}
+}

--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageMetadata.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageMetadata.java
@@ -21,7 +21,11 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+/**
+ * Use {@code DockerImageMetadata}
+ */
 @Slf4j
+@Deprecated
 public class ImageMetadata {
 
 	/**


### PR DESCRIPTION
**DockerImageMetadata**
- does not depend on jboss.dmr
- caches metadata for image streams
- checks for existing ones
- thread safe
- same api as ImageMetadata (means to replace it)

**SkipForCondition**
- uses DockerImageMetadata class
- gets name from metadata and applies the pattern

ImageMetadata class is deprecated now

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
