### PR TITLE
Failfast support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,6 +57,23 @@
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/core/src/main/java/cz/xtf/core/event/EventList.java
+++ b/core/src/main/java/cz/xtf/core/event/EventList.java
@@ -1,0 +1,130 @@
+package cz.xtf.core.event;
+
+
+import io.fabric8.kubernetes.api.model.Event;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Spliterator;
+
+/**
+ * List of events implementing {@link List} interface to easy up the work with events
+ */
+public class EventList implements List<Event> {
+
+	private final ArrayList<Event> eventList;
+
+	public EventList(List<Event> eventList) {
+		this.eventList = new ArrayList<>(eventList);
+	}
+	public EventListFilter filter() {
+		return new EventListFilter(this);
+	}
+
+	public boolean containsAll(Collection<?> c) {
+		return eventList.containsAll(c);
+	}
+
+	public boolean addAll(Collection<? extends Event> c) {
+		return eventList.addAll(c);
+	}
+
+	public boolean addAll(int index, Collection<? extends Event> c) {
+		return eventList.addAll(index, c);
+	}
+
+	public boolean equals(Object o) {
+		return eventList.equals(o);
+	}
+
+	public int hashCode() {
+		return eventList.hashCode();
+	}
+
+	public int size() {
+		return eventList.size();
+	}
+
+	public boolean isEmpty() {
+		return eventList.isEmpty();
+	}
+
+	public boolean contains(Object o) {
+		return eventList.contains(o);
+	}
+
+	public int indexOf(Object o) {
+		return eventList.indexOf(o);
+	}
+
+	public int lastIndexOf(Object o) {
+		return eventList.lastIndexOf(o);
+	}
+
+	public Object[] toArray() {
+		return eventList.toArray();
+	}
+
+	public <T> T[] toArray(T[] a) {
+		return eventList.toArray(a);
+	}
+
+	public boolean add(Event event) {
+		return eventList.add(event);
+	}
+
+	public void add(int index, Event element) {
+		eventList.add(index, element);
+	}
+
+	public Event get(int index) {
+		return eventList.get(index);
+	}
+
+	public Event set(int index, Event element) {
+		return eventList.set(index, element);
+	}
+
+	public Event remove(int index) {
+		return eventList.remove(index);
+	}
+
+	public boolean remove(Object o) {
+		return eventList.remove(o);
+	}
+
+	public void clear() {
+		eventList.clear();
+	}
+
+	public boolean removeAll(Collection<?> c) {
+		return eventList.removeAll(c);
+	}
+
+	public boolean retainAll(Collection<?> c) {
+		return eventList.retainAll(c);
+	}
+
+	public ListIterator<Event> listIterator(int index) {
+		return eventList.listIterator(index);
+	}
+
+	public ListIterator<Event> listIterator() {
+		return eventList.listIterator();
+	}
+
+	public Iterator<Event> iterator() {
+		return eventList.iterator();
+	}
+
+	public List<Event> subList(int fromIndex, int toIndex) {
+		return eventList.subList(fromIndex, toIndex);
+	}
+
+	public Spliterator<Event> spliterator() {
+		return eventList.spliterator();
+	}
+}

--- a/core/src/main/java/cz/xtf/core/event/EventListFilter.java
+++ b/core/src/main/java/cz/xtf/core/event/EventListFilter.java
@@ -1,0 +1,135 @@
+package cz.xtf.core.event;
+
+
+import cz.xtf.core.event.helpers.EventHelper;
+import io.fabric8.kubernetes.api.model.Event;
+
+import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EventListFilter {
+
+	private Stream<Event> stream;
+
+	public EventListFilter(EventList events) {
+		stream = events.stream();
+	}
+
+	/**
+	 * Filter events of types defined in the array (case insensitive).
+	 * For example: {@code Warning}, {@code Normal}, ...
+	 */
+	public EventListFilter ofEventTypes(String... types) {
+		stream = stream.filter(event -> isStrInArrayCaseInsensitive(event.getType(), types));
+		return this;
+	}
+
+	/**
+	 * Filter events with involved object kind defined in the array (case insensitive).
+	 * For example: {@code Warning}, {@code Normal}, ...
+	 */
+	public EventListFilter ofObjKinds(String... kinds) {
+		stream = stream.filter(event -> isStrInArrayCaseInsensitive(event.getInvolvedObject().getKind(), kinds));
+		return this;
+	}
+
+	/**
+	 * Return true if there is at least one event that match one of the given messages (reg. expressions)
+	 */
+	public boolean atLeastOneRegexMessages(String...messagesRegex) {
+		return stream.anyMatch(event -> {
+			for (String regex : messagesRegex) {
+				if (event.getMessage().matches(regex)) {
+					return true;
+				}
+			}
+			return false;
+		});
+	}
+
+	/**
+	 * Filter events with messages (reg. expressions) defined in the array.
+	 */
+	public EventListFilter ofMessages(String...messagesRegex) {
+		stream =  stream.filter(event -> {
+			for (String regex : messagesRegex) {
+				if (event.getMessage().matches(regex)) {
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	/**
+	 * Return filtered {@link EventList}
+	 */
+	public EventList collect() {
+		return new EventList(stream.collect(Collectors.toList()));
+	}
+
+	/**
+	 * Filter events with involved object name defined in the array of reg. expressions.
+	 */
+	public EventListFilter ofObjNames(String... regexNames) {
+		stream = stream.filter(event -> {
+			for (String regexName : regexNames) {
+				if (event.getInvolvedObject().getName().matches(regexName)) {
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	/**
+	 * Filter events that are last seen in any if given time windows.
+	 * A structure of the array should be: [from date], [until date], [from date] [until date],...
+	 * Event needs to be seen strictly after {@code from date} and before or at the same time as {@code until date}.
+	 *
+	 * {@link ZonedDateTime} is used because a OpenShift cluster is distributed and time is provided in {@link java.time.format.DateTimeFormatter#ISO_DATE_TIME}
+	 * format that consider time zones. Therefore wee need to compare it against {@link ZonedDateTime#now()} (for example)
+	 *
+	 * @see ZonedDateTime
+	 */
+	public EventListFilter inOneOfTimeWindows(ZonedDateTime... dates) {
+		stream = stream.filter(event -> {
+			if (event.getLastTimestamp() != null) {
+				ZonedDateTime eventDate = EventHelper.timestampToZonedDateTime(event.getLastTimestamp());
+				for (int i = 0; i < dates.length - 1; i += 2) {
+					if (eventDate.isAfter(dates[i]) && (eventDate.compareTo(dates[i + 1]) == 0 || eventDate.isBefore(dates[i + 1]))) {
+						return true;
+					}
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	/**
+	 * Filter events with involved object kind defined in the array (case insensitive).
+	 */
+	public EventListFilter ofReasons(String...reasons) {
+		stream = stream.filter(event -> isStrInArrayCaseInsensitive(event.getReason(), reasons));
+		return this;
+	}
+
+	public long count() {
+		return stream.count();
+	}
+
+
+	private boolean isStrInArrayCaseInsensitive(String str, String... array) {
+		String field = str.toLowerCase();
+		for (String item : array) {
+			if (field.equals(item.toLowerCase())) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/core/src/main/java/cz/xtf/core/event/helpers/EventHelper.java
+++ b/core/src/main/java/cz/xtf/core/event/helpers/EventHelper.java
@@ -1,0 +1,11 @@
+package cz.xtf.core.event.helpers;
+
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class EventHelper {
+	public static ZonedDateTime timestampToZonedDateTime(String timestamp) {
+		return ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_DATE_TIME);
+	}
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1,6 +1,7 @@
 package cz.xtf.core.openshift;
 
 import cz.xtf.core.config.WaitingConfig;
+import cz.xtf.core.event.EventList;
 import cz.xtf.core.openshift.crd.CustomResourceDefinitionContextProvider;
 import cz.xtf.core.waiting.SimpleWaiter;
 import cz.xtf.core.waiting.Waiter;
@@ -1094,6 +1095,14 @@ public class OpenShift extends DefaultOpenShiftClient {
 	}
 
 	// Events
+	public EventList getEventList() {
+		return new EventList(events().list().getItems());
+	}
+
+	/**
+	 * Use {@link OpenShift#getEventList()} instead
+	 */
+	@Deprecated
 	public List<Event> getEvents() {
 		return events().list().getItems();
 	}
@@ -1221,6 +1230,11 @@ public class OpenShift extends DefaultOpenShiftClient {
 	}
 
 	// Waiting
+
+	/**
+	 * Use {@link OpenShiftWaiters#get(OpenShift, BooleanSupplier)} instead.
+	 */
+	@Deprecated
 	public OpenShiftWaiters waiters() {
 		return waiters;
 	}

--- a/core/src/main/java/cz/xtf/core/waiting/Waiter.java
+++ b/core/src/main/java/cz/xtf/core/waiting/Waiter.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.slf4j.event.Level;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -118,6 +119,17 @@ public interface Waiter {
 	 */
 	default Waiter onTimeout(Runnable runnable) {
 		throw new UnsupportedOperationException("Method onTimeout hasn't been implemented.");
+	}
+
+	/**
+	 * Sets waiters fail fast function that indicates (returns true) if there is an error state and waiting should not
+	 * proceed.
+	 *
+	 * @param failFast returns true if waiting has failed.
+	 * @return this
+	 */
+	default Waiter failFast(BooleanSupplier failFast) {
+		throw new UnsupportedOperationException("Method failFast hasn't been implemented.");
 	}
 
 	/**

--- a/core/src/main/java/cz/xtf/core/waiting/helpers/ExponentialTimeBackoff.java
+++ b/core/src/main/java/cz/xtf/core/waiting/helpers/ExponentialTimeBackoff.java
@@ -1,0 +1,115 @@
+package cz.xtf.core.waiting.helpers;
+
+
+import java.util.Random;
+
+/**
+ * Class provide support for exponential time backoff. This is convenient if you need to check some event periodically.
+ * The class provides {@code next} method that implements wait (blocking or non-blocking - returns true/false whether code
+ * can proceed).
+ *
+ * Class wait time grow exponentially up to {@code maxBackoffMillis} time: 1sec, 2 sec, 4 sec, 8 sec,...,{@code maxBackoffMillis}.
+ */
+public class ExponentialTimeBackoff {
+	private long lastNonBlockingTime;
+	private boolean blocking;
+	private long maxBackoffMillis;
+
+	private long step;
+	private Random random;
+	private long nonBlockingWaitMillis;
+
+	private ExponentialTimeBackoff(Builder builder) {
+		blocking = builder.blocking;
+		maxBackoffMillis = builder.maxBackoffMillis;
+		step = 1;
+		random = new Random(System.currentTimeMillis());
+		lastNonBlockingTime = System.currentTimeMillis();
+		nonBlockingWaitMillis = waitMillisForCurrentStep();
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Exponential backoff wait.
+	 * If wait is blocking, {@link Thread#sleep} is called and true is always returned.
+	 * If wait is non-blocking, the method returns true if logic can proceed (enough time has elapsed)
+	 *
+	 * @return true if logic can proceed
+	 */
+	public boolean next() {
+		return blocking ? nextBlocking() : nextNonBlocking();
+	}
+
+	private boolean nextBlocking() {
+		try {
+			long wait = waitMillisForCurrentStep();
+			Thread.sleep(wait);
+			incrementStep();
+			return true;
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private boolean nextNonBlocking() {
+		long now = System.currentTimeMillis();
+		if (lastNonBlockingTime + nonBlockingWaitMillis <= now) {
+			incrementStep();
+			nonBlockingWaitMillis = waitMillisForCurrentStep();
+			lastNonBlockingTime = now;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private long waitMillisForCurrentStep() {
+		if (step * 1000 >= maxBackoffMillis) {
+			return maxBackoffMillis + random.nextInt(1000);
+		} else {
+			return step * 1000 + random.nextInt(1000);
+		}
+	}
+
+	private void incrementStep() {
+		if (step * 1000 < maxBackoffMillis) {
+			step *= 2;
+		}
+	}
+
+	public static class Builder {
+		static boolean DEFAULT_BLOCKING = false;
+		static long DEFAULT_MAX_BACKOFF = 1_000L;
+
+		private boolean blocking;
+		private long maxBackoffMillis;
+
+		private Builder() {
+			blocking = DEFAULT_BLOCKING;
+			maxBackoffMillis = DEFAULT_MAX_BACKOFF;
+		}
+
+		/**
+		 * Flag whether waiting is blocking or not
+		 */
+		public Builder blocking(boolean blocking) {
+			this.blocking = blocking;
+			return this;
+		}
+
+		/**
+		 * Maximum wait time is {@code maxBackoffMillis} + rand(1000)
+		 */
+		public Builder maxBackoff(long maxBackoffMillis) {
+			this.maxBackoffMillis = maxBackoffMillis;
+			return this;
+		}
+
+		public ExponentialTimeBackoff build() {
+			return new ExponentialTimeBackoff(this);
+		}
+	}
+}

--- a/core/src/main/java/cz/xtf/core/waiting/helpers/FailFastBoolSupplierBuilder.java
+++ b/core/src/main/java/cz/xtf/core/waiting/helpers/FailFastBoolSupplierBuilder.java
@@ -1,0 +1,198 @@
+package cz.xtf.core.waiting.helpers;
+
+
+import cz.xtf.core.config.BuildManagerConfig;
+import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.event.EventList;
+import cz.xtf.core.event.EventListFilter;
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+/**
+ * The class provides support to create {@link BooleanSupplier} that checks if a waiter should fail due to an error state
+ * of cluster. The function is supposed to be called by a {@link cz.xtf.core.waiting.Waiter}.
+ * If it returns true, the waiter should fail.
+ *
+ * Example of use:
+ * <pre>
+ *     FailFastBoolSupplierBuilder
+ *     		.ofOpenshiftAndBmNamespace()
+ *     		.events()
+ *     		.after(ZonedDateTime.now())
+ *     		.ofNames("my-app.*")
+ *     		.ofMessages("Failed.*")
+ *     		.atLeasOneExists()
+ *     		.build()
+ * </pre>
+ *
+ * You can create more checks for events and every one of them will be checked. If one of them returns true, the whole
+ * fail fast function returns true.
+ */
+public class FailFastBoolSupplierBuilder {
+
+	private final List<OpenShift> openShifts = new ArrayList<>();
+	private final List<BooleanSupplier> suppliers = new ArrayList<>();
+	private long intervalMillis;
+
+	private FailFastBoolSupplierBuilder(String... namespaces) {
+		intervalMillis = 1_000L;
+		if (namespaces.length == 0) {
+			openShifts.add(OpenShifts.master());
+		} else {
+			for (String namespace : namespaces) {
+				openShifts.add(OpenShifts.master(namespace));
+			}
+		}
+	}
+
+	public static FailFastBoolSupplierBuilder ofOpenshiftAndBmNamespace() {
+		return ofNamespaces(OpenShiftConfig.namespace(), BuildManagerConfig.namespace());
+	}
+
+	public static FailFastBoolSupplierBuilder ofNamespaces(String... namespaces) {
+		return new FailFastBoolSupplierBuilder(namespaces);
+	}
+
+	public EventFailFastBoolSupplierBuilder events() {
+		return new EventFailFastBoolSupplierBuilder(this);
+	}
+
+	private void addBoolSupplier(BooleanSupplier supplier) {
+		this.suppliers.add(supplier);
+	}
+
+	public FailFastBoolSupplierBuilder interval(long intervalMillis) {
+		this.intervalMillis = intervalMillis;
+		return this;
+	}
+
+	public BooleanSupplier build() {
+		return () -> {
+			for (BooleanSupplier supplier : suppliers) {
+				if (supplier.getAsBoolean()) {
+					return true;
+				}
+			}
+			return false;
+		};
+	}
+
+	public static class EventFailFastBoolSupplierBuilder {
+
+		private final FailFastBoolSupplierBuilder failFastBoolSupplierBuilder;
+		private String[] names = null;
+		private ZonedDateTime after;
+		private String[] reasons;
+		private String[] messages;
+		private String[] types;
+		private String[] kinds;
+
+		private EventFailFastBoolSupplierBuilder(FailFastBoolSupplierBuilder failFastBoolSupplierBuilder) {
+			this.failFastBoolSupplierBuilder = failFastBoolSupplierBuilder;
+		}
+
+		/**
+		 * Regexes to match event involved object name.
+		 */
+		public EventFailFastBoolSupplierBuilder ofNames(String... name) {
+			this.names = name;
+			return this;
+		}
+
+		/**
+		 * Array of demanded reasons of events (case in-sensitive). One of them must be equal.
+		 */
+		public EventFailFastBoolSupplierBuilder ofReasons(String... reasons) {
+			this.reasons = reasons;
+			return this;
+		}
+
+
+		/**
+		 * Array of demanded types of events (case in-sensitive). One of them must be equal.
+		 * For example: {@code Warning}, {@code Normal}, ...
+		 */
+		public EventFailFastBoolSupplierBuilder ofTypes(String... types) {
+			this.types = types;
+			return this;
+		}
+
+
+		/**
+		 * Array of demanded object kinds of events (case in-sensitive). One of them must be equal.
+		 * For example: {@code persistentvolume}, {@code pod}, ...
+		 */
+		public EventFailFastBoolSupplierBuilder ofKinds(String... kinds) {
+			this.kinds = kinds;
+			return this;
+		}
+
+		/**
+		 * Regexes for demanded messages. One of them must match.
+		 * @param messages
+		 * @return
+		 */
+		public EventFailFastBoolSupplierBuilder ofMessages(String... messages) {
+			this.messages = messages;
+			return this;
+		}
+
+		/**
+		 * If at least one event exist (after filtration), final function returns true.
+		 */
+		public FailFastBoolSupplierBuilder atLeastOneExists() {
+			// function is invoked every time...everytime we get events and filter them
+			failFastBoolSupplierBuilder.addBoolSupplier(() -> getFilterEventList().count() >= 1);
+			return failFastBoolSupplierBuilder;
+		}
+
+		/**
+		 * Consider event after certain time.
+		 */
+		public EventFailFastBoolSupplierBuilder after(ZonedDateTime after) {
+			this.after = after;
+			return this;
+		}
+
+		private EventListFilter getFilterEventList() {
+			EventListFilter filter = getEventsForAllNamespaces().filter();
+			if (names != null) {
+				filter.ofObjNames(names);
+			}
+			if (after != null) {
+				filter.inOneOfTimeWindows(after, ZonedDateTime.now());
+			}
+			if (reasons != null) {
+				filter.ofReasons(reasons);
+			}
+			if (messages != null) {
+				filter.ofMessages(messages);
+			}
+			if (types != null) {
+				filter.ofEventTypes(types);
+			}
+			if (kinds != null) {
+				filter.ofObjKinds(kinds);
+			}
+			return filter;
+		}
+
+		private EventList getEventsForAllNamespaces() {
+			EventList events = null;
+
+			for (OpenShift openShift : this.failFastBoolSupplierBuilder.openShifts) {
+				if (events == null) {
+					events = openShift.getEventList();
+				} else {
+					events.addAll(openShift.getEventList());
+				}
+			}
+			return events;
+		}
+	}
+}

--- a/core/src/test/java/cz/xtf/core/event/EventListTest.java
+++ b/core/src/test/java/cz/xtf/core/event/EventListTest.java
@@ -1,0 +1,303 @@
+package cz.xtf.core.event;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cz.xtf.core.event.helpers.EventHelper;
+import io.fabric8.kubernetes.api.model.Event;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EventListTest {
+
+	private static String eventTemplate =
+			"        {\n"
+					+ "            \"apiVersion\": \"v1\",\n"
+					+ "            \"count\": 1,\n"
+					+ "            \"eventTime\": null,\n"
+					+ "            \"firstTimestamp\": \"2020-05-22T06:17:43Z\",\n"
+					+ "            \"involvedObject\": {\n"
+					+ "                \"apiVersion\": \"v1\",\n"
+					+ "                \"fieldPath\": \"spec.containers{pv-recycler}\",\n"
+					+ "                \"kind\": \"%s\",\n" // PLACEHOLDER HERE
+					+ "                \"name\": \"%s\",\n" // PLACEHOLDER HERE
+					+ "                \"namespace\": \"default\",\n"
+					+ "                \"resourceVersion\": \"7611264\",\n"
+					+ "                \"uid\": \"cef5e166-cc1f-4403-8e11-026d6c050378\"\n"
+					+ "            },\n"
+					+ "            \"kind\": \"Event\",\n"
+					+ "            \"lastTimestamp\": \"%s\",\n" // PLACEHOLDER HERE
+					+ "            \"message\": \"%s\",\n" // PLACEHOLDER HERE
+					+ "            \"metadata\": {\n"
+					+ "                \"creationTimestamp\": \"2020-05-22T06:17:43Z\",\n"
+					+ "                \"name\": \"recycler-for-pv0005.1611453afcf35b01\",\n"
+					+ "                \"namespace\": \"default\",\n"
+					+ "                \"resourceVersion\": \"7611298\",\n"
+					+ "                \"selfLink\": \"/api/v1/namespaces/default/events/recycler-for-pv0005.1611453afcf35b01\",\n"
+					+ "                \"uid\": \"3769b0e9-f035-418c-b8ad-07419c06de06\"\n"
+					+ "            },\n"
+					+ "            \"reason\": \"%s\",\n" // PLACEHOLDER HERE
+					+ "            \"reportingComponent\": \"\",\n"
+					+ "            \"reportingInstance\": \"\",\n"
+					+ "            \"source\": {\n"
+					+ "                \"component\": \"kubelet\",\n"
+					+ "                \"host\": \"eapqe-007-srtg-rmf59-worker-znzs2\"\n"
+					+ "            },\n"
+					+ "            \"type\": \"%s\"\n" // PLACEHOLDER HERE
+					+ "        }\n";
+
+	private static Event event(String lastTimestamp, String involvedObjectkind, String involvedObjectName, String reason, String type, String message) throws JsonProcessingException {
+		return new ObjectMapper().readValue(String.format(eventTemplate, involvedObjectkind, involvedObjectName, lastTimestamp, message, reason, type), Event.class);
+	}
+
+	@Test
+	public void messageFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "Pod", "1", "Created", "Normal", "message2"),
+				event("2020-01-01T00:00:00Z", "Pod", "2", "Created", "Normal", "keyword abc"),
+				event("2020-01-01T00:00:00Z", "Pod", "3", "Created", "Normal", "random keyword random"),
+				event("2020-01-01T00:00:00Z", "Pod", "4", "Created", "Normal", "random another random"),
+				event("2020-01-01T00:00:00Z", "Pod", "5", "Created", "Normal", "message1")
+		));
+
+		EventList filtered = events.filter()
+				.ofMessages("keyword.*")
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("2", filtered.get(0).getInvolvedObject().getName());
+
+		filtered = events.filter()
+				.ofMessages(".*keyword.*", ".*another.*")
+				.collect();
+		Assertions.assertEquals(3, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("2"));
+		Assertions.assertTrue(names.contains("3"));
+		Assertions.assertTrue(names.contains("4"));
+
+		filtered = events.filter()
+				.ofMessages("nonexisting.*")
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void reasonFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "Pod", "1", "FailedToCreateEndpoint", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "2", "RecyclerPod", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "3", "VolumeRecycled", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "4", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "5", "VolumeRecycled", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.ofReasons("created")
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("4", filtered.get(0).getInvolvedObject().getName());
+
+		filtered = events.filter()
+				.ofReasons("recyclerPod", "VolumeRecycled")
+				.collect();
+		Assertions.assertEquals(3, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("2"));
+		Assertions.assertTrue(names.contains("3"));
+		Assertions.assertTrue(names.contains("5"));
+
+		filtered = events.filter()
+				.ofReasons("nonexisting.*")
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void objKindFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "persistentvolume", "1", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "2", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "enpoints", "3", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "4", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "weirdKind", "5", "Created", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.ofObjKinds("weirdkind")
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("5", filtered.get(0).getInvolvedObject().getName());
+
+		filtered = events.filter()
+				.ofObjKinds("persistentvolume", "pod")
+				.collect();
+		Assertions.assertEquals(3, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("1"));
+		Assertions.assertTrue(names.contains("2"));
+		Assertions.assertTrue(names.contains("4"));
+
+		filtered = events.filter()
+				.ofObjKinds("nonexisting.*")
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void typeFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "Pod", "1", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "2", "Created", "Warning", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "3", "Created", "Error", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "4", "Created", "Failure", "message"),
+				event("2020-01-01T00:00:00Z", "Pod", "5", "Created", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.ofEventTypes("error")
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("3", filtered.get(0).getInvolvedObject().getName());
+
+		filtered = events.filter()
+				.ofEventTypes("normal", "warning")
+				.collect();
+		Assertions.assertEquals(3, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("1"));
+		Assertions.assertTrue(names.contains("2"));
+		Assertions.assertTrue(names.contains("5"));
+
+		filtered = events.filter()
+				.ofEventTypes("nonexisting.*")
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void objNameFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "1", "oneapp-deploy", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "2", "two", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "3", "oneapp-runner", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "4", "three", "Created", "Normal", "message"),
+				event("2020-01-01T00:00:00Z", "5", "four", "Created", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.ofObjNames("two")
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("2", filtered.get(0).getInvolvedObject().getKind());
+
+		filtered = events.filter()
+				.ofObjNames("oneapp.*", "three.*")
+				.collect();
+		Assertions.assertEquals(3, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getKind())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("1"));
+		Assertions.assertTrue(names.contains("3"));
+		Assertions.assertTrue(names.contains("4"));
+
+		filtered = events.filter()
+				.ofEventTypes("nonexisting.*")
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void timeFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "Pod", "1", "Created", "Normal", "message"),
+				event("2020-01-01T01:00:00Z", "Pod", "2", "Created", "Normal", "message"),
+				event("2020-01-01T01:10:00Z", "Pod", "3", "Created", "Normal", "message"),
+				event("2020-01-01T02:00:00Z", "Pod", "4", "Created", "Normal", "message"),
+				event("2020-01-01T03:00:00Z", "Pod", "5", "Created", "Normal", "message"),
+				event("2020-01-01T03:33:00Z", "Pod", "6", "Created", "Normal", "message"),
+				event("2020-01-01T04:00:00Z", "Pod", "7", "Created", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.inOneOfTimeWindows(
+						EventHelper.timestampToZonedDateTime("2020-01-01T01:59:00Z"), EventHelper.timestampToZonedDateTime("2020-01-01T02:59:59Z"),
+						EventHelper.timestampToZonedDateTime("2020-01-01T04:00:01Z"),EventHelper.timestampToZonedDateTime("2021-01-01T03:00:01Z"))
+				.collect();
+		Assertions.assertEquals(1, filtered.size());
+		Assertions.assertEquals("4", filtered.get(0).getInvolvedObject().getName());
+
+		filtered = events.filter()
+				.inOneOfTimeWindows(
+						EventHelper.timestampToZonedDateTime("2020-01-01T00:59:00Z"), EventHelper.timestampToZonedDateTime("2020-01-01T02:59:59Z"),
+						EventHelper.timestampToZonedDateTime("2020-01-01T03:00:01Z"),EventHelper.timestampToZonedDateTime("2021-01-01T03:00:01Z"))
+				.collect();
+		Assertions.assertEquals(5, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("2"));
+		Assertions.assertTrue(names.contains("3"));
+		Assertions.assertTrue(names.contains("4"));
+		Assertions.assertTrue(names.contains("6"));
+		Assertions.assertTrue(names.contains("7"));
+
+		filtered = events.filter()
+				.inOneOfTimeWindows(EventHelper.timestampToZonedDateTime("2021-01-01T03:00:01Z"),EventHelper.timestampToZonedDateTime("2021-01-01T03:00:01Z"))
+				.collect();
+		Assertions.assertEquals(0, filtered.size());
+	}
+
+	@Test
+	public void multipleFiltrationTest() throws JsonProcessingException {
+		EventList events = new EventList(Arrays.asList(
+				event("2020-01-01T00:00:00Z", "Pod", "1", "Created", "Normal", "message"),
+				event("2020-01-01T01:00:00Z", "Pod", "2", "Created", "Normal", "message"),
+				event("2020-01-01T02:00:00Z", "deploymentconfig", "no-app-build", "error", "Normal", "message"),
+				event("2020-01-01T03:00:00Z", "deploymentconfig", "no-app-build", "Created", "Normal", "keyword"),
+				event("2020-01-01T04:00:00Z", "Pod", "5", "Created", "Normal", "message"),
+				event("2020-01-01T05:00:00Z", "Pod", "6", "Created", "Normal", "message"),
+				event("2020-01-01T06:00:00Z", "Pod", "7", "Created", "Normal", "message"),
+				// looking for this one
+				event("2020-01-01T07:00:00Z", "deploymentconfig", "myapp-deploy", "Created", "Normal", "buzz keyword noise"),
+				event("2020-01-01T07:20:00Z", "Pod", "myapp-xyz", "Created", "Normal", "message"),
+				event("2020-01-01T17:22:00Z", "deploymentconfig", "7", "Created", "Normal", "message"),
+				event("2020-01-01T11:00:00Z", "Pod", "7", "Created", "Normal", "message"),
+				event("2020-01-01T12:00:00Z", "deploymentconfig", "7", "Created", "Normal", "message"),
+				event("2020-01-01T13:00:00Z", "deploymentconfig", "7", "Created", "Normal", "message"),
+				event("2020-01-01T14:00:00Z", "Pod", "7", "Created", "Normal", "message"),
+				//looking for this one
+				event("2020-01-01T15:00:00Z", "Pod", "myapp-run", "failed", "Error", "silence foobar noise"),
+				event("2020-01-01T15:10:00Z", "Pod", "7", "Created", "Normal", "message")
+		));
+
+		EventList filtered = events.filter()
+				.inOneOfTimeWindows(
+						EventHelper.timestampToZonedDateTime("2020-01-01T06:30:00Z"), EventHelper.timestampToZonedDateTime("2020-01-01T07:30:00Z"),
+						EventHelper.timestampToZonedDateTime("2020-01-01T14:30:00Z"), EventHelper.timestampToZonedDateTime("2020-01-01T15:30:00Z"))
+				.ofEventTypes("normal", "error")
+				.ofMessages(".*keyword.*", ".*foobar.*")
+				.ofReasons("created", "failed")
+				.ofObjKinds("pod", "deploymentconfig")
+				.ofObjNames("myapp.*")
+				.collect();
+		Assertions.assertEquals(2, filtered.size());
+		List<String> names = filtered.stream()
+				.map(event -> event.getInvolvedObject().getName())
+				.collect(Collectors.toList());
+		Assertions.assertTrue(names.contains("myapp-deploy"));
+		Assertions.assertTrue(names.contains("myapp-run"));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<version.jboss-dmr>1.3.0.Final</version.jboss-dmr>
 		<version.junit5.platform>1.3.0</version.junit5.platform>
 		<version.junit5.jupiter>5.3.0</version.junit5.jupiter>
+		<version.junit5.jupiter.engine>5.3.0</version.junit5.jupiter.engine>
 		<version.assertj-core>3.5.2</version.assertj-core>
 		<version.lombok>1.16.22</version.lombok>
 		<version.gson>2.8.5</version.gson>
@@ -63,6 +64,7 @@
 		<version.maven-release-plugin>2.5.3</version.maven-release-plugin>
 		<version.maven-compiler-plugin>3.2</version.maven-compiler-plugin>
 		<version.maven-checkstyle-plugin>3.0.0</version.maven-checkstyle-plugin>
+		<version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
 	</properties>
 
 	<dependencyManagement>
@@ -146,6 +148,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>${version.junit5.jupiter.engine}</version>
+			</dependency>
+
+			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
 				<version>${version.assertj-core}</version>
@@ -169,6 +177,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${version.maven-surefire-plugin}</version>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
**EventList** and **EventListFilter**
- classes for storing and filtering events

**FailFastBoolSupplierBuilder**
- class for building bool supplier method that is used as function to check error state of cluster
- you can define which events show error state of cluster

**OpenShiftWaiters**
- added support for failfast approach
- defined waiters are with failfast function (empty by defeault) and returns false if failfast method returns true

@simkam @mnovak1 @LittleJohnII @mchoma 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
