### PR TITLE
Record resources states when test throws an exception

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -49,4 +49,8 @@ public class BuildManager {
 	public ManagedBuildReference getBuildReference(ManagedBuild managedBuild) {
 		return new ManagedBuildReference(managedBuild.getId(), "latest", openShift.getNamespace());
 	}
+
+	public OpenShift openShift() {
+		return openShift;
+	}
 }

--- a/core/src/main/java/cz/xtf/core/event/EventListFilter.java
+++ b/core/src/main/java/cz/xtf/core/event/EventListFilter.java
@@ -111,6 +111,18 @@ public class EventListFilter {
 	}
 
 	/**
+	 * Filter events that are last seen strictly after the date.
+	 */
+	public EventListFilter after(ZonedDateTime date) {
+		stream = stream.filter(e -> e.getLastTimestamp() != null && EventHelper.timestampToZonedDateTime(e.getLastTimestamp()).isAfter(date));
+		return this;
+	}
+
+	public Stream<Event> getStream() {
+		return stream;
+	}
+
+	/**
 	 * Filter events with involved object kind defined in the array (case insensitive).
 	 */
 	public EventListFilter ofReasons(String...reasons) {

--- a/core/src/main/java/cz/xtf/core/event/helpers/EventHelper.java
+++ b/core/src/main/java/cz/xtf/core/event/helpers/EventHelper.java
@@ -1,11 +1,48 @@
 package cz.xtf.core.event.helpers;
 
 
+import cz.xtf.core.config.BuildManagerConfig;
+import cz.xtf.core.event.EventList;
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class EventHelper {
 	public static ZonedDateTime timestampToZonedDateTime(String timestamp) {
 		return ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_DATE_TIME);
+	}
+
+	public static ZonedDateTime timeOfLastEventBMOrTestNamespaceOrEpoch() {
+		ZonedDateTime zonedDateTime = timeOfLastEvent(OpenShifts.master());
+		if (zonedDateTime == null) {
+			zonedDateTime = timeOfLastEvent(OpenShifts.master(BuildManagerConfig.namespace()));
+		}
+		return zonedDateTime != null ? zonedDateTime : ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC);
+	}
+
+	public static ZonedDateTime timeOfLastEvent(OpenShift openShift) {
+		EventList eventList = openShift.getEventList();
+		if (eventList.isEmpty()) {
+			return null;
+		}
+
+		eventList.sort((o1, o2) -> {
+			if (o1.getLastTimestamp() == null && o2.getLastTimestamp() == null) {
+				return 0;
+			} else if (o1.getLastTimestamp() == null) {
+				return 1;
+			} else if (o2.getLastTimestamp() == null) {
+				return -1;
+			} else {
+				ZonedDateTime o1Date = EventHelper.timestampToZonedDateTime(o1.getLastTimestamp());
+				ZonedDateTime o2Date = EventHelper.timestampToZonedDateTime(o2.getLastTimestamp());
+				return o1Date.compareTo(o2Date);
+			}
+		});
+		return EventHelper.timestampToZonedDateTime(eventList.get(eventList.size() - 1).getLastTimestamp());
 	}
 }

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -27,11 +27,13 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingBuilder;
 import io.fabric8.kubernetes.api.model.rbac.Subject;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.fabric8.kubernetes.client.AppsAPIGroupClient;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
@@ -90,6 +92,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 	private static volatile String routeSuffix;
 
 	public static final String KEEP_LABEL = "xtf.cz/keep";
+	private final AppsAPIGroupClient appsAPIGroupClient;
 
 	/**
 	 * Autoconfigures the client with the default fabric8 client rules
@@ -105,6 +108,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 		if (StringUtils.isNotEmpty(namespace)) {
 			openShiftConfig.setNamespace(namespace);
 		}
+
 
 		return new OpenShift(openShiftConfig);
 	}
@@ -171,6 +175,8 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public OpenShift(OpenShiftConfig openShiftConfig) {
 		super(openShiftConfig);
+
+		appsAPIGroupClient = new AppsAPIGroupClient(httpClient, openShiftConfig);
 
 		this.waiters = new OpenShiftWaiters(this);
 	}
@@ -316,6 +322,19 @@ public class OpenShift extends DefaultOpenShiftClient {
 
 	public List<ImageStream> getImageStreams() {
 		return imageStreams().list().getItems();
+	}
+
+	// StatefulSets
+	public StatefulSet createStatefulSet(StatefulSet statefulSet) {
+		return appsAPIGroupClient.statefulSets().create(statefulSet);
+	}
+
+	public StatefulSet getStatefulSet(String name) {
+		return appsAPIGroupClient.statefulSets().withName(name).get();
+	}
+
+	public List<StatefulSet> getStatefulSets() {
+		return appsAPIGroupClient.statefulSets().list().getItems();
 	}
 
 	public boolean deleteImageStream(ImageStream imageStream) {

--- a/junit5/README.md
+++ b/junit5/README.md
@@ -31,6 +31,9 @@ Reports test execution on the fly into one `log/junit-report.xml` file.
 ## Extensions
 Extensions enable better test management. Usable directly on classes and methods.
 
+##### @OpenShiftRecorder
+Record OpenShift state when a test throws an exception or use `xtf.record.always` to record on success. Specify app names (which will be turned into regexes) to filter resources by name. When not specified, everything in test and build namespace will be recorded (regex - `.*`). Use `xtf.record.dir` to set the directory.
+
 ##### @CleanBeforeAll/@CleanBeforeEach
 Cleans namespace specified by `xtf.openshift.namespace` property. Either before all tests or each test execution.
 

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
@@ -1,0 +1,26 @@
+package cz.xtf.junit5.annotations;
+
+import cz.xtf.junit5.extensions.OpenShiftRecorderHandler;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@see OpenShiftRecorderHandler}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@ExtendWith(OpenShiftRecorderHandler.class)
+public @interface OpenShiftRecorder {
+
+	/**
+	 * Resource names for filtering out events, pods,...
+	 * Will be turned into regex {@code __value__.*}
+	 *
+	 * {@see OpenShiftRecorderHandler}
+	 */
+	String[] objNames() default "";
+}

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
@@ -22,5 +22,5 @@ public @interface OpenShiftRecorder {
 	 *
 	 * {@see OpenShiftRecorderHandler}
 	 */
-	String[] objNames() default "";
+	String[] resourceNames() default "";
 }

--- a/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
+++ b/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
@@ -13,6 +13,16 @@ public class JUnitConfig {
 	private static final String CI_PASSWORD = "xtf.junit.ci.password";
 	private static final String JENKINS_RERUN = "xtf.junit.jenkins.rerun";
 	private static final String PREBUILDER_SYNCHRONIZED = "xtf.junit.prebuilder.synchronized";
+	private static final String RECORD_DIR = "xtf.record.dir";
+	private static final String RECORD_ALWAYS = "xtf.record.always";
+
+	public static String recordDir() {
+		return XTFConfig.get(RECORD_DIR);
+	}
+
+	public static boolean recordAlways() {
+		return XTFConfig.get(RECORD_ALWAYS) != null && (XTFConfig.get(RECORD_ALWAYS).equals("") || XTFConfig.get(RECORD_ALWAYS).toLowerCase().equals("true"));
+	}
 
 	public static boolean cleanOpenShift() {
 		return Boolean.valueOf(XTFConfig.get(CLEAN_OPENSHIFT, "false"));

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
@@ -1,0 +1,280 @@
+package cz.xtf.junit5.extensions;
+
+import cz.xtf.core.config.BuildManagerConfig;
+import cz.xtf.core.event.helpers.EventHelper;
+import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
+import cz.xtf.junit5.annotations.OpenShiftRecorder;
+import cz.xtf.junit5.config.JUnitConfig;
+import cz.xtf.junit5.extensions.helpers.ResourcesPrinterHelper;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.Route;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZonedDateTime;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Record OpenShift isolated state relative to a test.
+ * Resources are filtered by name provided via {@link OpenShiftRecorder} annotation. Names are turned into regexes
+ * by adding {@code .*} as a suffix. If no name is provided, all resources in namespaces (BM and normal) are considered;
+ * regex is {@code .*}.
+ * <p>
+ * Recorded resources:
+ * <ul>
+ * <li>pods states</li>
+ * <li>deployment configs states</li>
+ * <li>builds states</li>
+ * <li>build configs states</li>
+ * <li>image streams states</li>
+ * <li>stateful sets states</li>
+ * <li>routes states</li>
+ * <li>services states</li>
+ * <li>secrets states</li>
+ * <li>logs of pods</li>
+ * <li>events</li>
+ * </ul>
+ * <p>
+ * OpenShift state is recorded when a test throws an exception. If {@link JUnitConfig#RECORD_ALWAYS} is true, state is
+ * recored also when a test passes.
+ * <p>
+ * Use {@link JUnitConfig#RECORD_DIR} to set the direction of records.
+ */
+public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExceptionHandler, BeforeAllCallback {
+	private static final Logger log = LoggerFactory.getLogger(OpenShiftRecorderHandler.class);
+
+	private static final String TRACK_FROM = "TRACK_FROM";
+
+	@Override
+	public void beforeAll(ExtensionContext extensionContext) throws Exception {
+		getClassStore(extensionContext).put(TRACK_FROM, EventHelper.timeOfLastEventBMOrTestNamespaceOrEpoch());
+	}
+
+	@Override
+	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+		try {
+			recordState(context);
+		} catch (Throwable t) {
+			t.printStackTrace(System.err);
+		} finally {
+			throw throwable;
+		}
+	}
+
+	@Override
+	public void testSuccessful(ExtensionContext context) {
+		if (JUnitConfig.recordAlways()) {
+			try {
+				recordState(context);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	private void recordState(ExtensionContext context) throws IOException {
+		OpenShiftRecorder classOpenShiftRecorder = AnnotationSupport.findAnnotation(context.getRequiredTestClass(), OpenShiftRecorder.class).orElse(null);
+		OpenShiftRecorder methodOpenShiftRecorder = AnnotationSupport.findAnnotation(context.getElement(), OpenShiftRecorder.class).orElse(null);
+		final OpenShiftRecorder openShiftRecorder = methodOpenShiftRecorder != null ? methodOpenShiftRecorder : classOpenShiftRecorder;
+		// annotation or global include in META-INF.services (empty string will be turned into .* and no resource shall be filtered out)
+		String[] objNames = openShiftRecorder != null ? openShiftRecorder.objNames() : new String[]{""};
+
+		savePods(context, objNames);
+		saveDCs(context, objNames);
+		saveBuilds(context, objNames);
+		saveBCs(context, objNames);
+		saveISs(context, objNames);
+		saveStatefulsets(context, objNames);
+		saveRoutes(context, objNames);
+		saveServices(context, objNames);
+		saveSecrets(context, objNames);
+		savePodLogs(context, objNames);
+		saveEvents(context, objNames);
+
+	}
+
+	private void saveStatefulsets(ExtensionContext context, String[] objNames) throws IOException {
+		final Path StatefulSetsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "statefulSets.log");
+		try (final ResourcesPrinterHelper<StatefulSet> printer = ResourcesPrinterHelper.forStatefulSet(StatefulSetsLogPath)) {
+			OpenShifts.master().getStatefulSets().stream()
+					.filter(build -> resourceNameMatches(build.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveISs(ExtensionContext context, String[] objNames) throws IOException {
+		final Path imageStreamsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "imageStreams.log");
+		try (final ResourcesPrinterHelper<ImageStream> printer = ResourcesPrinterHelper.forISs(imageStreamsLogPath)) {
+			OpenShifts.master(BuildManagerConfig.namespace()).getImageStreams().stream()
+					.filter(build -> resourceNameMatches(build.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveBCs(ExtensionContext context, String[] objNames) throws IOException {
+		final Path buildsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "buildConfigs.log");
+		try (final ResourcesPrinterHelper<BuildConfig> printer = ResourcesPrinterHelper.forBCs(buildsLogPath)) {
+			OpenShifts.master(BuildManagerConfig.namespace()).getBuildConfigs().stream()
+					.filter(bc -> resourceNameMatches(bc.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveBuilds(ExtensionContext context, String[] objNames) throws IOException {
+		final Path buildsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "builds.log");
+		try (final ResourcesPrinterHelper<Build> printer = ResourcesPrinterHelper.forBuilds(buildsLogPath)) {
+			OpenShifts.master(BuildManagerConfig.namespace()).getBuilds().stream()
+					.filter(build -> resourceNameMatches(build.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveSecrets(ExtensionContext context, String[] objNames) throws IOException {
+		final Path secretsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "secrets.log");
+		try (final ResourcesPrinterHelper<Secret> printer = ResourcesPrinterHelper.forSecrets(secretsLogPath)) {
+			OpenShifts.master().getSecrets()
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveServices(ExtensionContext context, String[] objNames) throws IOException {
+		final Path servicesLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "services.log");
+		try (final ResourcesPrinterHelper<Service> printer = ResourcesPrinterHelper.forServices(servicesLogPath)) {
+			OpenShifts.master().getServices().stream()
+					.filter(service -> resourceNameMatches(service.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void saveRoutes(ExtensionContext context, String[] objNames) throws IOException {
+		final Path routesLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "routes.log");
+		try (final ResourcesPrinterHelper<Route> printer = ResourcesPrinterHelper.forRoutes(routesLogPath)) {
+			OpenShifts.master().getRoutes().stream()
+					.filter(route -> resourceNameMatches(route.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+	}
+
+	private void savePods(ExtensionContext context, String[] objNames) throws IOException {
+		// master namespace
+		final Path podsMasterLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "pods-" + OpenShifts.master().getNamespace() + ".log");
+		try (final ResourcesPrinterHelper<Pod> printer = ResourcesPrinterHelper.forPods(podsMasterLogPath)) {
+			OpenShifts.master().getPods()
+					.stream()
+					.filter(pod -> resourceNameMatches(pod.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+		}
+		// builds namespace (if not same)
+		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
+			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "pods-" + BuildManagerConfig.namespace() + ".log");
+			try (final ResourcesPrinterHelper<Pod> printer = ResourcesPrinterHelper.forPods(eventsBMLogPath)) {
+				OpenShifts.master(BuildManagerConfig.namespace()).getPods()
+						.stream()
+						.filter(pod -> resourceNameMatches(pod.getMetadata().getName(), objNames))
+						.forEach(printer::row);
+			}
+		}
+	}
+
+	private void saveDCs(ExtensionContext context, String[] objNames) throws IOException {
+		final Path dcsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "deploymentConfigs.log");
+		try (final ResourcesPrinterHelper<DeploymentConfig> printer = ResourcesPrinterHelper.forDCs(dcsLogPath)) {
+			OpenShifts.master().getDeploymentConfigs().stream()
+					.filter(dc -> resourceNameMatches(dc.getMetadata().getName(), objNames))
+					.forEach(printer::row);
+
+		}
+	}
+
+	private Store getClassStore(ExtensionContext extensionContext) {
+		return extensionContext.getStore(Namespace.create(extensionContext.getRequiredTestClass()));
+	}
+
+	private void savePodLogs(ExtensionContext context, String[] resourceNames) {
+		Consumer<OpenShift> podPrinter = openShift -> openShift.getPods()
+				.stream()
+				.filter(pod -> resourceNameMatches(pod.getMetadata().getName(), resourceNames))
+				.forEach(pod -> {
+					try {
+						openShift.storePodLog(
+								pod,
+								Paths.get(attachmentsDir(), dirNameForTest(context)),
+								pod.getMetadata().getName() + ".log");
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				});
+
+		podPrinter.accept(OpenShifts.master());
+		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
+			podPrinter.accept(OpenShifts.master(BuildManagerConfig.namespace()));
+		}
+	}
+
+	private String dirNameForTest(ExtensionContext context) {
+		return context.getTestClass().get().getName() + "." + context.getTestMethod().get().getName();
+	}
+
+	private void saveEvents(ExtensionContext context, String[] resourceNames) throws IOException {
+		Store classStore = getClassStore(context);
+		BiConsumer<OpenShift, ResourcesPrinterHelper<Event>> eventPrinter = (openShift, printer) -> openShift.getEventList().filter()
+				.ofObjNames(getRegexResourceNames(resourceNames))
+				.after(classStore.get(TRACK_FROM, ZonedDateTime.class))
+				.getStream()
+				.forEach(printer::row);
+
+		// master namespace
+		final Path eventsMasterLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "events-" + OpenShifts.master().getNamespace() + ".log");
+		try (final ResourcesPrinterHelper<Event> printer = ResourcesPrinterHelper.forEvents(eventsMasterLogPath)) {
+			eventPrinter.accept(OpenShifts.master(), printer);
+		}
+		// builds namespace (if not same)
+		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
+			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "events-" + BuildManagerConfig.namespace() + ".log");
+			try (final ResourcesPrinterHelper<Event> printer = ResourcesPrinterHelper.forEvents(eventsBMLogPath)) {
+				eventPrinter.accept(OpenShifts.master(BuildManagerConfig.namespace()), printer);
+			}
+		}
+	}
+
+	private boolean resourceNameMatches(String resourceName, String[] resourceNamesLookup) {
+		for (String resourceNameLookup : getRegexResourceNames(resourceNamesLookup)) {
+			if (resourceName.matches(resourceNameLookup)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private String[] getRegexResourceNames(String[] resourceNames) {
+		String[] result = new String[resourceNames.length];
+		for (int i = 0; i < resourceNames.length; i++) {
+			result[i] = resourceNames[i] + ".*";
+		}
+		return result;
+	}
+
+	private String attachmentsDir() {
+		return JUnitConfig.recordDir() != null ? JUnitConfig.recordDir() : System.getProperty("user.dir");
+	}
+}

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
@@ -1,6 +1,6 @@
 package cz.xtf.junit5.extensions;
 
-import cz.xtf.core.config.BuildManagerConfig;
+import cz.xtf.core.bm.BuildManagers;
 import cz.xtf.core.event.helpers.EventHelper;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
@@ -125,7 +125,7 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 	private void saveISs(ExtensionContext context, String[] objNames) throws IOException {
 		final Path imageStreamsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "imageStreams.log");
 		try (final ResourcesPrinterHelper<ImageStream> printer = ResourcesPrinterHelper.forISs(imageStreamsLogPath)) {
-			OpenShifts.master(BuildManagerConfig.namespace()).getImageStreams().stream()
+			BuildManagers.get().openShift().getImageStreams().stream()
 					.filter(build -> resourceNameMatches(build.getMetadata().getName(), objNames))
 					.forEach(printer::row);
 		}
@@ -134,7 +134,7 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 	private void saveBCs(ExtensionContext context, String[] objNames) throws IOException {
 		final Path buildsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "buildConfigs.log");
 		try (final ResourcesPrinterHelper<BuildConfig> printer = ResourcesPrinterHelper.forBCs(buildsLogPath)) {
-			OpenShifts.master(BuildManagerConfig.namespace()).getBuildConfigs().stream()
+			BuildManagers.get().openShift().getBuildConfigs().stream()
 					.filter(bc -> resourceNameMatches(bc.getMetadata().getName(), objNames))
 					.forEach(printer::row);
 		}
@@ -143,7 +143,7 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 	private void saveBuilds(ExtensionContext context, String[] objNames) throws IOException {
 		final Path buildsLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "builds.log");
 		try (final ResourcesPrinterHelper<Build> printer = ResourcesPrinterHelper.forBuilds(buildsLogPath)) {
-			OpenShifts.master(BuildManagerConfig.namespace()).getBuilds().stream()
+			BuildManagers.get().openShift().getBuilds().stream()
 					.filter(build -> resourceNameMatches(build.getMetadata().getName(), objNames))
 					.forEach(printer::row);
 		}
@@ -185,10 +185,10 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 					.forEach(printer::row);
 		}
 		// builds namespace (if not same)
-		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
-			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "pods-" + BuildManagerConfig.namespace() + ".log");
+		if (!OpenShifts.master().getNamespace().equals(BuildManagers.get().openShift().getNamespace())) {
+			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "pods-" + BuildManagers.get().openShift().getNamespace() + ".log");
 			try (final ResourcesPrinterHelper<Pod> printer = ResourcesPrinterHelper.forPods(eventsBMLogPath)) {
-				OpenShifts.master(BuildManagerConfig.namespace()).getPods()
+				BuildManagers.get().openShift().getPods()
 						.stream()
 						.filter(pod -> resourceNameMatches(pod.getMetadata().getName(), objNames))
 						.forEach(printer::row);
@@ -226,8 +226,8 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 				});
 
 		podPrinter.accept(OpenShifts.master());
-		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
-			podPrinter.accept(OpenShifts.master(BuildManagerConfig.namespace()));
+		if (!OpenShifts.master().getNamespace().equals(BuildManagers.get().openShift().getNamespace())) {
+			podPrinter.accept(BuildManagers.get().openShift());
 		}
 	}
 
@@ -249,10 +249,10 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 			eventPrinter.accept(OpenShifts.master(), printer);
 		}
 		// builds namespace (if not same)
-		if (!OpenShifts.master().getNamespace().equals(BuildManagerConfig.namespace())) {
-			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "events-" + BuildManagerConfig.namespace() + ".log");
+		if (!OpenShifts.master().getNamespace().equals(BuildManagers.get().openShift().getNamespace())) {
+			final Path eventsBMLogPath = Paths.get(attachmentsDir(), dirNameForTest(context), "events-" + BuildManagers.get().openShift().getNamespace() + ".log");
 			try (final ResourcesPrinterHelper<Event> printer = ResourcesPrinterHelper.forEvents(eventsBMLogPath)) {
-				eventPrinter.accept(OpenShifts.master(BuildManagerConfig.namespace()), printer);
+				eventPrinter.accept(BuildManagers.get().openShift(), printer);
 			}
 		}
 	}

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
@@ -56,7 +56,7 @@ import java.util.function.Consumer;
  * </ul>
  * <p>
  * OpenShift state is recorded when a test throws an exception. If {@link JUnitConfig#RECORD_ALWAYS} is true, state is
- * recored also when a test passes.
+ * recorded also when a test passes.
  * <p>
  * Use {@link JUnitConfig#RECORD_DIR} to set the direction of records.
  */
@@ -75,7 +75,7 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 		try {
 			recordState(context);
 		} catch (Throwable t) {
-			t.printStackTrace(System.err);
+			log.error("Throwable: ", t);
 		} finally {
 			throw throwable;
 		}
@@ -97,7 +97,7 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 		OpenShiftRecorder methodOpenShiftRecorder = AnnotationSupport.findAnnotation(context.getElement(), OpenShiftRecorder.class).orElse(null);
 		final OpenShiftRecorder openShiftRecorder = methodOpenShiftRecorder != null ? methodOpenShiftRecorder : classOpenShiftRecorder;
 		// annotation or global include in META-INF.services (empty string will be turned into .* and no resource shall be filtered out)
-		String[] objNames = openShiftRecorder != null ? openShiftRecorder.objNames() : new String[]{""};
+		String[] objNames = openShiftRecorder != null ? openShiftRecorder.resourceNames() : new String[]{""};
 
 		savePods(context, objNames);
 		saveDCs(context, objNames);

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesPrinterHelper.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesPrinterHelper.java
@@ -1,0 +1,171 @@
+package cz.xtf.junit5.extensions.helpers;
+
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.Route;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public class ResourcesPrinterHelper<X> implements AutoCloseable {
+	private final Path file;
+	private final Function<X, String[]> resourceToCols;
+	private final int[] maxLengths;
+	private final List<String[]> rows;
+
+	private ResourcesPrinterHelper(Path file, Function<X, String[]> resourceToCols, String... colNames) {
+		this.file = file;
+		this.resourceToCols = resourceToCols;
+		maxLengths = new int[colNames.length];
+		rows = new ArrayList<>();
+		row(colNames);
+	}
+
+	public static ResourcesPrinterHelper<Event> forEvents(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getEventCols, "FIRST SEEN", "LAST SEEN", "COUNT", "TYPE", "REASON", "OBJECT", "MESSAGE");
+	}
+
+	public static ResourcesPrinterHelper<Pod> forPods(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getPodCols, "NAME", "READY", "STATUS", "RESTARTS");
+	}
+
+	public static ResourcesPrinterHelper<DeploymentConfig> forDCs(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getDCsCols, "NAME", "READY");
+	}
+
+	public static ResourcesPrinterHelper<Route> forRoutes(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getRoutesCols, "NAME", "HOST", "SERVICES");
+	}
+
+	public static ResourcesPrinterHelper<Service> forServices(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getServicesCols, "NAME", "SELECTOR", "PORTS");
+	}
+
+	public static ResourcesPrinterHelper<Secret> forSecrets(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getSecretsCols, "NAME", "TYPE");
+	}
+
+	public static ResourcesPrinterHelper<Build> forBuilds(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getBuildCols, "NAME", "TYPE", "FROM", "STATUS", "STARTED", "DURATION");
+	}
+
+	public static ResourcesPrinterHelper<BuildConfig> forBCs(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getBCCols, "NAME", "TYPE", "FROM", "LATEST");
+	}
+
+
+	public static ResourcesPrinterHelper<ImageStream> forISs(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getISCols, "NAME", "IMAGE REPOSITORY");
+	}
+
+	public static ResourcesPrinterHelper<StatefulSet> forStatefulSet(Path filePath) {
+		return new ResourcesPrinterHelper<>(filePath, ResourcesPrinterHelper::getStatefulSetCols, "NAME", "REPLICAS");
+	}
+
+	private static String[] getStatefulSetCols(StatefulSet statefulSet) {
+		return new String[]{statefulSet.getMetadata().getName(), statefulSet.getStatus().getReadyReplicas() + "/" + statefulSet.getStatus().getReplicas()};
+	}
+
+	private static String[] getISCols(ImageStream is) {
+		return new String[]{is.getMetadata().getName(), is.getStatus().getPublicDockerImageRepository()};
+	}
+
+	private static String[] getBCCols(BuildConfig bc) {
+		return new String[]{bc.getMetadata().getName(), bc.getSpec().getStrategy().getType(), bc.getSpec().getSource().getType(),
+				String.valueOf(bc.getStatus().getLastVersion())};
+	}
+
+	private static String[] getBuildCols(Build build) {
+		return new String[]{build.getMetadata().getName(), build.getSpec().getStrategy().getType(), build.getSpec().getSource().getType(),
+				build.getStatus().getPhase(), build.getStatus().getStartTimestamp(), (build.getStatus().getDuration() / 1000000000) + "s"};
+	}
+
+	private static String[] getEventCols(Event event) {
+		return new String[]{event.getFirstTimestamp(), event.getLastTimestamp(), String.valueOf(event.getCount()),
+				event.getType(), event.getReason(),
+				event.getInvolvedObject().getKind() + "/" + event.getInvolvedObject().getName().replaceFirst("(.*?)\\..*", "$1"),
+				event.getMessage()};
+	}
+
+	private static String[] getPodCols(Pod pod) {
+		int restart = pod.getStatus().getContainerStatuses().stream()
+				.map(ContainerStatus::getRestartCount)
+				.mapToInt(Integer::intValue)
+				.sum();
+		long ready = pod.getStatus().getContainerStatuses().stream().filter(ContainerStatus::getReady).count();
+		long total = pod.getStatus().getContainerStatuses().size();
+		return new String[]{pod.getMetadata().getName(), ready + "/" + total, pod.getStatus().getPhase(), String.valueOf(restart)};
+	}
+
+	private static String[] getDCsCols(DeploymentConfig dc) {
+		return new String[]{dc.getMetadata().getName(), dc.getStatus().getReadyReplicas() + "/" + dc.getStatus().getReplicas()};
+	}
+
+	private static String[] getRoutesCols(Route route) {
+		return new String[]{route.getMetadata().getName(), route.getSpec().getHost(), route.getSpec().getTo().getName()};
+	}
+
+	private static String[] getSecretsCols(Secret secret) {
+		return new String[]{secret.getMetadata().getName(), secret.getType()};
+	}
+
+	private static String[] getServicesCols(Service service) {
+		final StringBuilder selector = new StringBuilder();
+		service.getSpec().getSelector().forEach((k, v) -> selector.append(k).append("=").append(v).append(";"));
+		final StringBuilder ports = new StringBuilder();
+		service.getSpec().getPorts().stream()
+				.forEach(port -> ports.append(port.getPort()).append("->").append(port.getTargetPort().getIntVal()).append(";"));
+		return new String[]{service.getMetadata().getName(), selector.toString(), ports.toString()};
+	}
+
+	public void row(X resource) {
+		row(resourceToCols.apply(resource));
+	}
+
+	public void row(String... cols) {
+		for (int i = 0; i < cols.length; i++) {
+			maxLengths[i] = Math.max(maxLengths[i], cols[i].length());
+		}
+		rows.add(cols);
+	}
+
+	@Override
+	public void close() throws IOException {
+		flush();
+	}
+
+	public void flush() throws IOException {
+		file.getParent().toFile().mkdirs();
+
+		try (final Writer writer = new OutputStreamWriter(new FileOutputStream(file.toFile()), StandardCharsets.UTF_8)) {
+			StringBuilder formatBuilder = new StringBuilder();
+			for (int maxLength : maxLengths) {
+				formatBuilder.append("%-").append(maxLength + 2).append("s");
+			}
+			String format = formatBuilder.toString();
+
+			StringBuilder result = new StringBuilder();
+			for (String[] row : rows) {
+				writer.append(String.format(format, row)).append("\n");
+			}
+			writer.flush();
+		}
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
 		<version.rxjava>1.3.0</version.rxjava>
 		<version.jboss-dmr>1.3.0.Final</version.jboss-dmr>
 		<version.junit5.platform>1.3.0</version.junit5.platform>
-		<version.junit5.jupiter>5.3.0</version.junit5.jupiter>
-		<version.junit5.jupiter.engine>5.3.0</version.junit5.jupiter.engine>
+		<version.junit5.jupiter>5.5.1</version.junit5.jupiter>
+		<version.junit5.jupiter.engine>5.5.1</version.junit5.jupiter.engine>
 		<version.assertj-core>3.5.2</version.assertj-core>
 		<version.lombok>1.16.22</version.lombok>
 		<version.gson>2.8.5</version.gson>


### PR DESCRIPTION
Add support to selectively save logs (pod logs, events,...) when a test throws an exception

You can specify resource names that will be considered (involved object names of events, names of pods,...).
It is turned into regular expression.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
