### PR TITLE
Store openshift state if before* fails.

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
+++ b/junit5/src/main/java/cz/xtf/junit5/config/JUnitConfig.java
@@ -15,6 +15,7 @@ public class JUnitConfig {
 	private static final String PREBUILDER_SYNCHRONIZED = "xtf.junit.prebuilder.synchronized";
 	private static final String RECORD_DIR = "xtf.record.dir";
 	private static final String RECORD_ALWAYS = "xtf.record.always";
+	private static final String RECORD_BEFORE = "xtf.record.before";
 
 	public static String recordDir() {
 		return XTFConfig.get(RECORD_DIR);
@@ -22,6 +23,10 @@ public class JUnitConfig {
 
 	public static boolean recordAlways() {
 		return XTFConfig.get(RECORD_ALWAYS) != null && (XTFConfig.get(RECORD_ALWAYS).equals("") || XTFConfig.get(RECORD_ALWAYS).toLowerCase().equals("true"));
+	}
+
+	public static boolean recordBefore() {
+		return XTFConfig.get(RECORD_BEFORE) != null && (XTFConfig.get(RECORD_BEFORE).equals("") || XTFConfig.get(RECORD_BEFORE).toLowerCase().equals("true"));
 	}
 
 	public static boolean cleanOpenShift() {

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderHandler.java
@@ -85,7 +85,9 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 	@Override
 	public void handleBeforeAllMethodExecutionException(final ExtensionContext context, final Throwable throwable) throws Throwable {
 		try {
-			recordState(context);
+			if (JUnitConfig.recordBefore()){
+				recordState(context);
+			}
 		} catch (Throwable t) {
 			log.error("Throwable: ", t);
 		} finally {
@@ -96,7 +98,9 @@ public class OpenShiftRecorderHandler implements TestWatcher, TestExecutionExcep
 	@Override
 	public void handleBeforeEachMethodExecutionException(final ExtensionContext context, final Throwable throwable) throws Throwable {
 		try {
-			recordState(context);
+			if (JUnitConfig.recordBefore()) {
+				recordState(context);
+			}
 		} catch (Throwable t) {
 			log.error("Throwable: ", t);
 		} finally {


### PR DESCRIPTION
Record openshift state even if beforeAll or beforeEach method fails.