### PR TITLE
OpenShiftRecorder - automatic resource filtration

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/OpenShiftRecorder.java
@@ -20,7 +20,8 @@ public @interface OpenShiftRecorder {
     /**
      * Resource names for filtering out events, pods,...
      * Will be turned into regex {@code __value__.*}
-     *
+     * <p>
+     * If no value is given resources are filtered automatically by recording what resources are seen before test and so on.
      * {@see OpenShiftRecorderHandler}
      */
     String[] resourceNames() default "";

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/EventsFilterBuilder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/EventsFilterBuilder.java
@@ -1,0 +1,20 @@
+package cz.xtf.junit5.extensions.helpers;
+
+import java.time.ZonedDateTime;
+
+import io.fabric8.kubernetes.api.model.Event;
+
+public class EventsFilterBuilder extends ResourcesFilterBuilder<Event> {
+
+    @Override
+    String getResourceName(Event event) {
+        return event.getInvolvedObject().getName();
+    }
+
+    @Override
+    ZonedDateTime getResourceTime(Event event) {
+        String result = event.getLastTimestamp();
+        return result == null ? super.getResourceTime(event)
+                : ResourcesTimestampHelper.parseZonedDateTime(event.getLastTimestamp());
+    }
+}

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesFilterBuilder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesFilterBuilder.java
@@ -1,0 +1,113 @@
+package cz.xtf.junit5.extensions.helpers;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+public class ResourcesFilterBuilder<E extends HasMetadata> implements Cloneable {
+
+    FilterMethod method;
+    String[] resourceNames;
+    ZonedDateTime excludeUntil;
+    ZonedDateTime includeAlwaysAfter;
+    ZonedDateTime includeAlwaysUntil;
+
+    public Predicate<E> build() {
+        switch (method) {
+            case RESOURCE_NAMES:
+                return resource -> resourceNameMatches(getResourceName(resource), resourceNames);
+            case PREVIOUSLY_SEEN_RESOURCES:
+                return resource -> {
+                    ZonedDateTime time = getResourceTime(resource);
+                    return (includeAlwaysAfter != null && includeAlwaysUntil != null && time.isAfter(includeAlwaysAfter)
+                            && !time.isAfter(includeAlwaysUntil))
+                            || (excludeUntil != null && time.isAfter(excludeUntil));
+                };
+            default:
+                return resource -> true;
+        }
+    }
+
+    String getResourceName(E item) {
+        return item.getMetadata().getName();
+    }
+
+    ZonedDateTime getResourceTime(E item) {
+        return ResourcesTimestampHelper.parseZonedDateTime(item.getMetadata().getCreationTimestamp());
+    }
+
+    public ZonedDateTime getExcludedUntil() {
+        return excludeUntil;
+    }
+
+    /**
+     * Resources until the time will be excluded. Lower priority than
+     * {@link ResourcesFilterBuilder#setIncludedAlwaysWindow(ZonedDateTime, ZonedDateTime)}.
+     * It the resource is in the {@code always included window} it will be included
+     */
+    public ResourcesFilterBuilder setExcludedUntil(ZonedDateTime until) {
+        this.excludeUntil = until;
+        return this;
+    }
+
+    /**
+     * Resources in the window will be always included despite {@link ResourcesFilterBuilder#setExcludedUntil(ZonedDateTime)}.
+     */
+    public ResourcesFilterBuilder setIncludedAlwaysWindow(ZonedDateTime after, ZonedDateTime until) {
+        this.includeAlwaysAfter = after;
+        this.includeAlwaysUntil = until;
+        return this;
+    }
+
+    public ZonedDateTime getIncludedAlwaysWindowAfter() {
+        return includeAlwaysAfter;
+    }
+
+    public ZonedDateTime getIncludedAlwaysWindowUntil() {
+        return includeAlwaysUntil;
+    }
+
+    public ResourcesFilterBuilder filterByResourceNames() {
+        method = FilterMethod.RESOURCE_NAMES;
+        return this;
+    }
+
+    public ResourcesFilterBuilder filterByLastSeenResources() {
+        method = FilterMethod.PREVIOUSLY_SEEN_RESOURCES;
+        return this;
+    }
+
+    public ResourcesFilterBuilder setResourceNames(String... resourceNames) {
+        this.resourceNames = Arrays.copyOf(resourceNames, resourceNames.length);
+        return this;
+    }
+
+    @Override
+    public ResourcesFilterBuilder<E> clone() throws CloneNotSupportedException {
+        return (ResourcesFilterBuilder<E>) super.clone();
+    }
+
+    boolean resourceNameMatches(String resourceName, String[] resourceNamesLookup) {
+        for (String resourceNameLookup : getRegexResourceNames(resourceNamesLookup)) {
+            if (resourceName.matches(resourceNameLookup)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    String[] getRegexResourceNames(String[] resourceNames) {
+        String[] result = new String[resourceNames.length];
+        for (int i = 0; i < resourceNames.length; i++) {
+            result[i] = resourceNames[i] + ".*";
+        }
+        return result;
+    }
+
+    enum FilterMethod {
+        RESOURCE_NAMES,
+        PREVIOUSLY_SEEN_RESOURCES
+    }
+}

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesTimestampHelper.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/helpers/ResourcesTimestampHelper.java
@@ -1,0 +1,112 @@
+package cz.xtf.junit5.extensions.helpers;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import cz.xtf.core.openshift.OpenShift;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.openshift.api.model.Build;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.ImageStream;
+import io.fabric8.openshift.api.model.Route;
+
+public class ResourcesTimestampHelper {
+
+    static ZonedDateTime lastCreationTime(List<? extends HasMetadata> items) {
+        ZonedDateTime result = null;
+        for (HasMetadata item : items) {
+            ZonedDateTime time = parseZonedDateTime(item.getMetadata().getCreationTimestamp());
+            if (result == null || time.isAfter(result)) {
+                result = time;
+            }
+        }
+        return result == null ? ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC) : result;
+    }
+
+    // todo delete?
+    static ZonedDateTime creationTime(HasMetadata item) {
+        return ZonedDateTime.parse(item.getMetadata().getCreationTimestamp(), DateTimeFormatter.ISO_DATE_TIME);
+    }
+
+    static ZonedDateTime parseZonedDateTime(String time) {
+        return ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME);
+    }
+
+    public static ZonedDateTime timeOfLastPod(OpenShift openShift) {
+        return lastCreationTime(openShift.getPods());
+    }
+
+    public static ZonedDateTime timeOfLastDC(OpenShift openShift) {
+        return lastCreationTime(openShift.getDeploymentConfigs());
+    }
+
+    public static ZonedDateTime timeOfLastBC(OpenShift openShift) {
+        return lastCreationTime(openShift.getBuildConfigs());
+    }
+
+    public static ZonedDateTime timeOfLastBuild(OpenShift openShift) {
+        return lastCreationTime(openShift.getBuilds());
+    }
+
+    public static ZonedDateTime timeOfLastIS(OpenShift openShift) {
+        return lastCreationTime(openShift.getImageStreams());
+    }
+
+    public static ZonedDateTime timeOfLastSS(OpenShift openShift) {
+        return lastCreationTime(openShift.getStatefulSets());
+    }
+
+    public static ZonedDateTime timeOfLastRoute(OpenShift openShift) {
+        return lastCreationTime(openShift.getRoutes());
+    }
+
+    public static ZonedDateTime timeOfLastService(OpenShift openShift) {
+        return lastCreationTime(openShift.getServices());
+    }
+
+    public static ZonedDateTime timeOfLastEvent(OpenShift openShift) {
+        ZonedDateTime result = null;
+        for (Event event : openShift.getEvents()) {
+            if (event.getLastTimestamp() == null) {
+                continue;
+            }
+            ZonedDateTime time = parseZonedDateTime(event.getLastTimestamp());
+            if (result == null || (time != null && time.isAfter(result))) {
+                result = time;
+            }
+        }
+        return result == null ? ZonedDateTime.ofInstant(Instant.ofEpochSecond(0), ZoneOffset.UTC) : result;
+    }
+
+    public static ZonedDateTime timeOfLastResourceOf(OpenShift openShift, Class<? extends HasMetadata> resourceClass) {
+        if (resourceClass.equals(Pod.class)) {
+            return timeOfLastPod(openShift);
+        } else if (resourceClass.equals(DeploymentConfig.class)) {
+            return timeOfLastDC(openShift);
+        } else if (resourceClass.equals(BuildConfig.class)) {
+            return timeOfLastBC(openShift);
+        } else if (resourceClass.equals(Build.class)) {
+            return timeOfLastBuild(openShift);
+        } else if (resourceClass.equals(ImageStream.class)) {
+            return timeOfLastIS(openShift);
+        } else if (resourceClass.equals(StatefulSet.class)) {
+            return timeOfLastSS(openShift);
+        } else if (resourceClass.equals(Route.class)) {
+            return timeOfLastRoute(openShift);
+        } else if (resourceClass.equals(Service.class)) {
+            return timeOfLastService(openShift);
+        } else if (resourceClass.equals(Event.class)) {
+            return timeOfLastEvent(openShift);
+        } else {
+            throw new RuntimeException("Unsupported resource - " + resourceClass.getName());
+        }
+    }
+}


### PR DESCRIPTION
f not resource name is provided then filter resources automatically. A resource is logged if is created after a test starts (window for @BeforeAll is considered)

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
