### PR TITLE
[feature] Label every created namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # XTF
-XTF is framework designed to easy up aspects of testing in OpenShift environment.
+XTF is a framework designed to ease up aspects of testing in OpenShift environment.
 
 
 ## Modules
@@ -7,12 +7,12 @@ XTF is framework designed to easy up aspects of testing in OpenShift environment
 Core concepts of XTF framework used by other modules.
 
 #### Configuration
-While framework itself doesn't require any configuration it can easy up some repetative settings in tests. Setup of XTF can be done in 4 ways with priority from top to down:
+While the framework itself doesn't require any configuration, it can ease up some repetitive settings in tests. Setup of XTF can be done in 4 ways with priority from top to down:
 
 * System properties 
 * Environment variables
 * `test.properties` file in root of the project designed to contain user specific setup. You can use `-Dxtf.test_properties.path` property to specify the location for the desired user specific setup.
-* `global-test.properties` file in root of the project designed to contain shared setup. You can use `-Dxtf.global_test_properties.path` property to specify the location for the desired user specific setup.
+* `global-test.properties` file in root of the project designed to contain a shared setup. You can use `-Dxtf.global_test_properties.path` property to specify the location for the desired user specific setup.
 
 The mapping between system properties and environment variables is done by lower casing environment variable, replacing `_` with `.` and adding `xtf.` before the result.
 
@@ -21,7 +21,7 @@ Example: `OPENSHIFT_MASTER_URL` is mapped to `xtf.openshift.master.url`.
 #### OpenShift
 [OpenShift](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/openshift/OpenShift.java) class is entry point for communicating with OpenShift. It extends `OpenShiftNamespaceClient` from Fabric8 client as is meant to be used within one namespace where tests are executed.
 
-`OpenShift` class extends upstream version with several shortcuts. Eg. using deploymentconfig name only for retrieving any `Pod` or its log. This is usefull in test cases where we know that we have only one pod created by dc or we don't care which one will we get. The class itself also provides access to OpenShift specific `Waiters`.
+`OpenShift` class extends upstream version with several shortcuts. Eg. using deploymentconfig name only for retrieving any `Pod` or its log. This is useful in test cases where we know that we have only one pod created by dc or we don't care which one will we get. The class itself also provides access to OpenShift specific `Waiters`.
 
 ##### Configuration:
 Take a look at [OpenShiftConfig](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java) class to see possible configurations. Enabling some them will allow you to instantiate as `OpenShift openShift = OpenShifts.master()`.
@@ -51,7 +51,7 @@ XTF provides two different implementations ([SimpleWaiter](https://github.com/xt
 `Https.doesUrlReturnsOK("http://example.com").timeOut(TimeUnit.MINUTES, 10).waitFor();`
 
 #### BuildManager
-[BuildManager](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/bm/BuildManager.java) cachces test builds in one namespace so they can be reused. After first time specified ManagedBuild succeds only the reference is returned but build is already present.
+[BuildManager](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/bm/BuildManager.java) caches test builds in one namespace so they can be reused. After first time specified ManagedBuild succeeds only the reference is returned but build is already present.
 
 ```
 BuildManager bm = new BuildManagers.get();
@@ -62,7 +62,7 @@ bm.hasBuildCompleted().waitFor();
 ```
 
 #### Image
-Wrapper class for url specified images. It's puprose is to parse them or turn them into ImageStream objects.
+Wrapper class for url specified images. Its purpose is to parse them or turn them into ImageStream objects.
 
 ##### Specifying images
 Every image that is set in `global-test.properties` using xtf.{foo}.image can be accessed by using `Images.get(foo)`.
@@ -90,4 +90,4 @@ xtf.foo.v2.version=1.0.3
 Retrieving an instance with this metadata: `Produts.resolve("product");`
 
 ### JUnit5
-JUnit5 module provides number of extensions and listeners designed to easy up OpenShift images test management. See [JUnit5](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/SimpleWaiter.java) for more informations. 
+JUnit5 module provides number of extensions and listeners designed to easy up OpenShift images test management. See [JUnit5](https://github.com/xtf-cz/xtf/blob/master/core/src/main/java/cz/xtf/core/waiting/SimpleWaiter.java) for more information. 

--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -3,7 +3,9 @@ package cz.xtf.core.bm;
 import cz.xtf.core.config.BuildManagerConfig;
 import cz.xtf.core.config.OpenShiftConfig;
 import cz.xtf.core.openshift.OpenShift;
+import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.Waiter;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -16,6 +18,24 @@ public class BuildManager {
         if (openShift.getProject(openShift.getNamespace()) == null) {
             openShift.createProjectRequest();
             openShift.waiters().isProjectReady().waitFor();
+
+            try {
+                // Adding a label can be only done via 'namespace'. It cannot be set via 'project' API. Thus we do this
+                // separately. Also, to update namespace label, it's necessary to have 'patch resource "namespaces"'
+                // permission for current user and updated namespace, e.g. by having 'cluster-admin' role.
+                // Otherwise you can see:
+                // $ oc label namespace <name> "label1=foo"
+                // Error from server (Forbidden): namespaces "<name>" is forbidden: User "<user>" cannot patch resource "namespaces" in API group "" in the namespace "<name>"
+                OpenShifts.admin().namespaces().withName(openShift.getNamespace()).edit().editMetadata().addToLabels(
+                        OpenShift.XTF_MANAGED_LABEL, "true").endMetadata().done();
+            } catch (KubernetesClientException e) {
+                // We weren't able to assign a label to the new project. Let's just print warning since this information
+                // is not critical to the tests execution. Possible cause for this are insufficient permissions since
+                // some projects using XTF are executed on OCP instances without 'admin' accounts available.
+                log.warn("Couldn't assign label '" + OpenShift.XTF_MANAGED_LABEL + "' to the new project '"
+                        + openShift.getNamespace() + "'. Possible cause are insufficient permissions.");
+                log.debug(e.getMessage());
+            }
         }
         if (OpenShiftConfig.pullSecret() != null) {
             openShift.setupPullSecret(OpenShiftConfig.pullSecret());

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -93,6 +93,12 @@ public class OpenShift extends DefaultOpenShiftClient {
     private static volatile String routeSuffix;
 
     public static final String KEEP_LABEL = "xtf.cz/keep";
+    /**
+     * This label is supposed to be used for any resource created by the XTF to easily distinguish which resources have
+     * been created by XTF automation.
+     * NOTE: at the moment only place where this is used is for labeling namespaces. Other usages may be added in the future.
+     */
+    public static final String XTF_MANAGED_LABEL = "xtf.cz/managed";
     private final AppsAPIGroupClient appsAPIGroupClient;
 
     /**

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -253,7 +253,7 @@ public class OpenShift extends DefaultOpenShiftClient {
     }
 
     /**
-     * Calls rectreateProject(namespace).
+     * Calls recreateProject(namespace).
      *
      * @see OpenShift#recreateProject(String)
      */
@@ -265,7 +265,7 @@ public class OpenShift extends DefaultOpenShiftClient {
      * Creates or recreates project specified by name.
      *
      * @param name name of a project to be created
-     * @return ProjectRequest instatnce
+     * @return ProjectRequest instance
      */
     public ProjectRequest recreateProject(String name) {
         return recreateProject(new ProjectRequestBuilder().withNewMetadata().withName(name).endMetadata().build());
@@ -274,7 +274,7 @@ public class OpenShift extends DefaultOpenShiftClient {
     /**
      * Creates or recreates project specified by projectRequest instance.
      *
-     * @return ProjectRequest instatnce
+     * @return ProjectRequest instance
      */
     public ProjectRequest recreateProject(ProjectRequest projectRequest) {
         boolean deleted = deleteProject(projectRequest.getMetadata().getName());
@@ -287,7 +287,7 @@ public class OpenShift extends DefaultOpenShiftClient {
     }
 
     /**
-     * Tries to retreive project with name 'name'. Swallows KubernetesClientException
+     * Tries to retrieve project with name 'name'. Swallows KubernetesClientException
      * if project doesn't exist or isn't accessible for user.
      *
      * @param name name of requested project.

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
@@ -11,7 +11,10 @@ import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.SimpleWaiter;
 import cz.xtf.junit5.config.JUnitConfig;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class ProjectCreator implements TestExecutionListener {
     private static final OpenShift openShift = OpenShifts.master();
 
@@ -20,6 +23,24 @@ public class ProjectCreator implements TestExecutionListener {
         if (openShift.getProject() == null) {
             openShift.createProjectRequest();
             openShift.waiters().isProjectReady().waitFor();
+
+            try {
+                // Adding a label can be only done via 'namespace'. It cannot be set via 'project' API. Thus we do this
+                // separately. Also, to update namespace label, it's necessary to have 'patch resource "namespaces"'
+                // permission for current user and updated namespace, e.g. by having 'cluster-admin' role.
+                // Otherwise you can see:
+                // $ oc label namespace <name> "label1=foo"
+                // Error from server (Forbidden): namespaces "<name>" is forbidden: User "<user>" cannot patch resource "namespaces" in API group "" in the namespace "<name>"
+                OpenShifts.admin().namespaces().withName(openShift.getProject().getMetadata().getName()).edit().editMetadata()
+                        .addToLabels(OpenShift.XTF_MANAGED_LABEL, "true").endMetadata().done();
+            } catch (KubernetesClientException e) {
+                // We weren't able to assign a label to the new project. Let's just print warning since this information
+                // is not critical to the tests execution. Possible cause for this are insufficient permissions since
+                // some projects using XTF are executed on OCP instances without 'admin' accounts available.
+                log.warn("Couldn't assign label '" + OpenShift.XTF_MANAGED_LABEL + "' to the new project '"
+                        + openShift.getNamespace() + "'. Possible cause are insufficient permissions.");
+                log.debug(e.getMessage());
+            }
         }
         if (OpenShiftConfig.pullSecret() != null) {
             openShift.setupPullSecret(OpenShiftConfig.pullSecret());


### PR DESCRIPTION
Motivation for this is to have some common label for the projects/namespaces created by XTF automatically. This can ease their listing and tracing.

So far we search based on the 'openshift.io/requester' annotation value.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
