### PR TITLE
Allow customization of maven activation script location

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ bm.hasBuildCompleted().waitFor();
 #### Image
 Wrapper class for url specified images. Its purpose is to parse them or turn them into ImageStream objects.
 
+##### Specifying Maven
+In some images Maven needs to be activated, for example on RHEL7 via script `/opt/rh/rh-maven35/enable`. 
+This can be controlled by properties.
+
+ * `xtf.maven.script` - path to Maven activation script. Defaults to `/opt/rh/rh-maven35/enable` if not set.
+
+Not setting these options might result in faulty results from `ImageContent#mavenVersion()`.
+
 ##### Specifying images
 Every image that is set in `global-test.properties` using xtf.{foo}.image can be accessed by using `Images.get(foo)`.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Wrapper class for url specified images. Its purpose is to parse them or turn the
 In some images Maven needs to be activated, for example on RHEL7 via script `/opt/rh/rh-maven35/enable`. 
 This can be controlled by properties.
 
- * `xtf.maven.script` - path to Maven activation script. Defaults to `/opt/rh/rh-maven35/enable` if not set.
+ * `xtf.maven.activation_script` - path to Maven activation script. Defaults to `/opt/rh/rh-maven35/enable` if not set.
 
 Not setting these options might result in faulty results from `ImageContent#mavenVersion()`.
 

--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -1,5 +1,13 @@
 package cz.xtf.testhelpers.image;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import cz.xtf.core.config.WaitingConfig;
 import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.openshift.OpenShift;
@@ -11,14 +19,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ImageContent {
     public static final String RED_HAT_RELEASE_KEY_2 = "199e2f91fd431d51";

--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -143,8 +143,7 @@ public class ImageContent {
      * In RHEL7, maven needs to be added to path via enable script. This is a default behaviour of this method.
      * Behaviour can be changed by changing XTFConfig properties.
      * <ul>
-     * <li><i>xtf.maven.script.disabled</i> - set to "true" if maven enabling should not be done
-     * <li><i>xtf.maven.script</i> - set to path to maven enable script. Default: <code>/opt/rh/rh-maven35/enable</code>
+     * <li><i>xtf.maven.activation_script</i> - set to path to maven enable script. Default: <code>/opt/rh/rh-maven35/enable</code>
      * </ul>
      *
      * @return version of Maven in the image.
@@ -174,7 +173,7 @@ public class ImageContent {
      * @return
      */
     private String getMavenActivationScript(String mavenScriptPath) {
-        String mavenEnableScript = XTFConfig.get("xtf.maven.script", "/opt/rh/rh-maven35/enable");
+        String mavenEnableScript = XTFConfig.get("xtf.maven.activation_script", "/opt/rh/rh-maven35/enable");
         return "echo . " + mavenEnableScript + " >> " + mavenScriptPath;
     }
 

--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -143,7 +143,8 @@ public class ImageContent {
      * In RHEL7, maven needs to be added to path via enable script. This is a default behaviour of this method.
      * Behaviour can be changed by changing XTFConfig properties.
      * <ul>
-     * <li><i>xtf.maven.activation_script</i> - set to path to maven enable script. Default: <code>/opt/rh/rh-maven35/enable</code>
+     * <li><i>xtf.maven.activation_script</i> - set to path to maven enable script. Default:
+     * <code>/opt/rh/rh-maven35/enable</code>
      * </ul>
      *
      * @return version of Maven in the image.
@@ -168,9 +169,6 @@ public class ImageContent {
 
     /**
      * Return script for adding maven activation command to maven script.
-     *
-     * @param mavenScriptPath
-     * @return
      */
     private String getMavenActivationScript(String mavenScriptPath) {
         String mavenEnableScript = XTFConfig.get("xtf.maven.activation_script", "/opt/rh/rh-maven35/enable");


### PR DESCRIPTION
As Maven 3.5 has reached EOL, RHEL will be moving to Maven 3.6. This will lead to change in the way Maven is added to the path. This PR adds a configuration `xtf.maven.activation_script` to allow to change maven activation script location. 

On systems where Maven activation script is not needed, the resulting script does not fail and correctly returns current Maven version.

Change is backwards compatible and defaults to current behaviour.

https://github.com/xtf-cz/xtf/issues/425
https://issues.redhat.com/browse/CLOUD-3955

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
