### PR TITLE
Provide link to MIT license used for XTF + other metadata about project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,14 @@
         <module>test-helpers</module>
     </modules>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
     <scm>
         <connection>scm:git:git@github.com:xtf-cz/xtf.git</connection>
         <developerConnection>scm:git:git@github.com:xtf-cz/xtf.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,8 @@
     <packaging>pom</packaging>
     <version>0.22-SNAPSHOT</version>
     <name>XTF</name>
+    <description>XTF is a framework designed to ease up aspects of testing in OpenShift environment.</description>
+    <url>https://github.com/xtf-cz/xtf/</url>
 
     <modules>
         <module>core</module>
@@ -22,7 +24,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <scm>
         <connection>scm:git:git@github.com:xtf-cz/xtf.git</connection>
         <developerConnection>scm:git:git@github.com:xtf-cz/xtf.git</developerConnection>


### PR DESCRIPTION
There is already LICENSE file (https://github.com/xtf-cz/xtf/blob/master/LICENSE). This is just mentioning it in the pom.xml to fullfill requirements for public Maven repos. 