### PR TITLE
Allow change to PostgreSQL and MySQL readiness and liveness probe settings

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/MySQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/MySQL.java
@@ -1,6 +1,5 @@
 package cz.xtf.builder.db;
 
-import cz.xtf.builder.builders.pod.ContainerBuilder;
 import cz.xtf.builder.builders.pod.PersistentVolumeClaim;
 import cz.xtf.core.image.Image;
 
@@ -37,12 +36,11 @@ public class MySQL extends AbstractSQLDatabase {
     }
 
     @Override
-    protected void configureContainer(ContainerBuilder containerBuilder) {
-        if (withLivenessProbe)
-            containerBuilder.addLivenessProbe().setInitialDelay(30).createTcpProbe("3306");
-        if (withReadinessProbe)
-            containerBuilder.addReadinessProbe().setInitialDelaySeconds(5).createExecProbe("/bin/sh", "-i", "-c",
-                    "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'");
+    protected ProbeSettings getProbeSettings() {
+        return new ProbeSettings(30,
+                String.valueOf(getPort()),
+                5,
+                "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'");
     }
 
     @Override

--- a/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
@@ -2,7 +2,6 @@ package cz.xtf.builder.db;
 
 import java.util.Map;
 
-import cz.xtf.builder.builders.pod.ContainerBuilder;
 import cz.xtf.builder.builders.pod.PersistentVolumeClaim;
 import cz.xtf.core.image.Image;
 
@@ -42,13 +41,11 @@ public class PostgreSQL extends AbstractSQLDatabase {
         return 5432;
     }
 
-    @Override
-    protected void configureContainer(ContainerBuilder containerBuilder) {
-        if (withLivenessProbe)
-            containerBuilder.addLivenessProbe().setInitialDelay(300).createTcpProbe("5432");
-        if (withReadinessProbe)
-            containerBuilder.addReadinessProbe().setInitialDelaySeconds(5).createExecProbe("/bin/sh", "-i", "-c",
-                    "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'");
+    protected ProbeSettings getProbeSettings() {
+        return new ProbeSettings(300,
+                String.valueOf(getPort()),
+                5,
+                "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'");
     }
 
     @Override

--- a/builder/src/main/java/cz/xtf/builder/db/ProbeSettings.java
+++ b/builder/src/main/java/cz/xtf/builder/db/ProbeSettings.java
@@ -1,0 +1,17 @@
+package cz.xtf.builder.db;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+public class ProbeSettings {
+    private int livenessInitialDelaySeconds;
+    private String livenessTcpProbe;
+    private int readinessInitialDelaySeconds;
+    private String readinessProbeCommand;
+}


### PR DESCRIPTION
Allow XTF library user to change probe settings by overriding `getProbeSettings` in his classes
Do not change behaviour and probe settings for Derby, MySQL, and PostgreSQL

What I did:
* Pulled duplicate code for liveness and readiness up into `AbstractSQLDatabase.java`
* Extracted MySQL and PostgreSQL probe settings from `configureContainer` to `ProbeSettings.java`

XTF library user will:
* derive his own class, for example `GalleonConfiguredDatasourcePostgreSQL extends PostgreSQL`
* optionally override `getProbeSettings`, using `super.getProbeSettings()` and updating them:
```java
public class GalleonConfiguredDatasourcePostgreSQL extends PostgreSQL {
// ...
	@Override
	protected ProbeSettings getProbeSettings() {
		ProbeSettings settings = super.getProbeSettings();
		settings.setReadinessInitialDelaySeconds(10);
		return settings;
	}
// ...
}
```

Please make sure your PR meets the following requirements:
- [ ] Pull Request contains a description of the changes
- [ ] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented
