### PR TITLE
Replacing hardcoded 10 mins waiting with WaitingConfig.timeout for OpenShiftWaiters#hasBuildCompleted

### DIFF
--- a/core/src/main/java/cz/xtf/core/config/WaitingConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/WaitingConfig.java
@@ -6,10 +6,12 @@ public class WaitingConfig {
     public static final String WAITING_TIMEOUT = "xtf.waiting.timeout";
     public static final String WAITING_LOG_LEVEL = "xtf.waiting.log.level";
     public static final String WAITING_TIMEOUT_CLEANUP = "xtf.waiting.timeout.cleanup";
+    public static final String WAITING_BUILD_TIMEOUT = "xtf.waiting.build.timeout";
 
     private static final String WAITING_TIMEOUT_DEFAULT = "180000";
     private static final String WAITING_LOG_LEVEL_DEFAULT = "INFO";
     private static final String WAITING_TIMEOUT_CLEANUP_DEFAULT = "20000";
+    private static final String WAITING_BUILD_TIMEOUT_DEFAULT = "600000";
 
     public static long timeout() {
         return Long.parseLong(XTFConfig.get(WAITING_TIMEOUT, WAITING_TIMEOUT_DEFAULT));
@@ -21,5 +23,9 @@ public class WaitingConfig {
 
     public static long timeoutCleanup() {
         return Long.parseLong(XTFConfig.get(WAITING_TIMEOUT_CLEANUP, WAITING_TIMEOUT_CLEANUP_DEFAULT));
+    }
+
+    public static long buildTimeout() {
+        return Long.parseLong(XTFConfig.get(WAITING_BUILD_TIMEOUT, WAITING_BUILD_TIMEOUT_DEFAULT));
     }
 }

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
@@ -45,8 +45,9 @@ public class OpenShiftWaiters {
     }
 
     /**
-     * Creates waiter for latest build completion with preconfigured timeout 10 minutes,
-     * 5 seconds interval check and both logging points.
+     * Creates waiter for latest build completion with a build timeout which is preconfigured to be up to 10 minutes
+     * (but can also be customized by setting {@code xtf.waiting.build.timeout}), 5 seconds interval check and both
+     * logging points.
      *
      * @param buildConfigName build name to wait upon
      * @return Waiter instance
@@ -58,15 +59,17 @@ public class OpenShiftWaiters {
                 .orElse(null);
         String reason = "Waiting for completion of latest build " + buildConfigName;
 
-        return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MINUTES, 10, reason)
-                .logPoint(Waiter.LogPoint.BOTH)
-                .failFast(failFast)
-                .interval(5_000);
+        return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MINUTES,
+                WaitingConfig.buildTimeout(), reason)
+                        .logPoint(Waiter.LogPoint.BOTH)
+                        .failFast(failFast)
+                        .interval(5_000);
     }
 
     /**
-     * Creates waiter for build completion with preconfigured timeout 10 minutes,
-     * 5 seconds interval check and both logging points.
+     * Creates waiter for build completion with a build timeout which is preconfigured to be up to 10 minutes (but can
+     * also be customized by setting {@code xtf.waiting.build.timeout}), 5 seconds interval check and both logging
+     * points.
      *
      * @param build to be waited upon.
      * @return Waiter instance
@@ -75,10 +78,11 @@ public class OpenShiftWaiters {
         Supplier<String> supplier = () -> openShift.getBuild(build.getMetadata().getName()).getStatus().getPhase();
         String reason = "Waiting for completion of build " + build.getMetadata().getName();
 
-        return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MINUTES, 10, reason)
-                .logPoint(Waiter.LogPoint.BOTH)
-                .failFast(failFast)
-                .interval(5_000);
+        return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MINUTES,
+                WaitingConfig.buildTimeout(), reason)
+                        .logPoint(Waiter.LogPoint.BOTH)
+                        .failFast(failFast)
+                        .interval(5_000);
     }
 
     /**


### PR DESCRIPTION
Using configuration values rather than some hardcoded timeouts in OpenShiftWaiters.
 
Fix https://github.com/xtf-cz/xtf/issues/438

FYI @mchoma

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
