### PR TITLE
Revert Fabric8 4.10 backward compatibility fix (#374) ad718b27

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1110,15 +1110,7 @@ public class OpenShift extends DefaultOpenShiftClient {
         return configMaps().delete(configMap);
     }
 
-    // Templates
-    private void updateTemplateApiVersion(Template template) {
-        if (OpenShifts.getVersion().startsWith("3")) {
-            template.setApiVersion("template.openshift.io/v1");
-        }
-    }
-
     public Template createTemplate(Template template) {
-        updateTemplateApiVersion(template);
         return templates().create(template);
     }
 
@@ -1135,7 +1127,6 @@ public class OpenShift extends DefaultOpenShiftClient {
     }
 
     public boolean deleteTemplate(Template template) {
-        updateTemplateApiVersion(template);
         return templates().delete(template);
     }
 


### PR DESCRIPTION
as fabric8io/kubernetes-client#2373 was fixed, api version guessing can be streamlined.

Please make sure your PR meets the following requirements:
- [ ] Pull Request contains a description of the changes
- [ ] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented
