### PR TITLE
Fix - ignore openshift-service-ca.crt config map - needed for OCP 4.8…

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -1096,13 +1096,14 @@ public class OpenShift extends DefaultOpenShiftClient {
     }
 
     /**
-     * Retrieves all configmaps but "kube-root-ca.crt" which is created out of the box.
+     * Retrieves all configmaps but "kube-root-ca.crt" and "openshift-service-ca.crt" which are created out of the box.
      *
      * @return List of configmaps created by user
      */
     public List<ConfigMap> getUserConfigMaps() {
         return configMaps().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems().stream()
                 .filter(cm -> !cm.getMetadata().getName().equals("kube-root-ca.crt"))
+                .filter(cm -> !cm.getMetadata().getName().equals("openshift-service-ca.crt"))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
…+ to avoid failures during cleaning up of namespace - see issue https://github.com/xtf-cz/xtf/issues/449

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
