### PR TITLE
make TestExecutionLogger thread safe

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/listeners/TestExecutionLogger.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/TestExecutionLogger.java
@@ -1,7 +1,7 @@
 package cz.xtf.junit5.listeners;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class TestExecutionLogger implements TestExecutionListener {
-    private Map<String, Long> executionTimes = new HashMap<>();
+    private Map<String, Long> executionTimes = new ConcurrentHashMap<>();
 
     @Override
     public void executionSkipped(TestIdentifier testIdentifier, String reason) {


### PR DESCRIPTION
to avoid races like
```
Aug 06, 2021 1:23:55 PM org.junit.platform.launcher.core.TestExecutionListenerRegistry lambda$notifyEach$1
WARNING: TestExecutionListener [cz.xtf.junit5.listeners.TestExecutionLogger] threw exception for method: executionFinished(TestIdentifier [uniqueId = '[engine:junit-jupiter]/[class:com.redhat.xpaas.eap.microprofile.health.MPHealthUpTest]/[method:healthCheckUpTest()]', parentId = '[engine:junit-jupiter]/[class:com.redhat.xpaas.eap.microprofile.health.MPHealthUpTest]', displayName = 'healthCheckUpTest()', legacyReportingName = 'healthCheckUpTest()', source = MethodSource [className = 'com.redhat.xpaas.eap.microprofile.health.MPHealthUpTest', methodName = 'healthCheckUpTest', methodParameterTypes = ''], tags = [level2, openshift-api], type = TEST], TestExecutionResult [status = SUCCESSFUL, throwable = null])
java.lang.NullPointerException
        at cz.xtf.junit5.listeners.TestExecutionLogger.executionFinished(TestExecutionLogger.java:39)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry$CompositeTestExecutionListener.lambda$executionFinished$10(TestExecutionListenerRegistry.java:109)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.lambda$notifyEach$1(TestExecutionListenerRegistry.java:67)
        at java.util.ArrayList.forEach(ArrayList.java:1257)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.notifyEach(TestExecutionListenerRegistry.java:65)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry.access$200(TestExecutionListenerRegistry.java:32)
        at org.junit.platform.launcher.core.TestExecutionListenerRegistry$CompositeTestExecutionListener.executionFinished(TestExecutionListenerRegistry.java:108)
        at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:56)
        at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:46)
        at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.executionFinished(OutcomeDelayingEngineExecutionListener.java:63)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.reportCompletion(NodeTestTask.java:183)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:89)
        at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:185)
        at java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:189)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

According to https://github.com/junit-team/junit5/issues/2539#issuecomment-766325555, only `testPlanExecutionStarted` and `testPlanExecutionFinished` are always called from the same thread. All other method could be called from different threads concurrently in case one or multiple test engines execute tests in parallel.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
