### PR TITLE
bump openshift-client to 5.7.x

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
@@ -11,6 +11,8 @@ import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.SimpleWaiter;
 import cz.xtf.junit5.config.JUnitConfig;
+import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,8 +33,14 @@ public class ProjectCreator implements TestExecutionListener {
                 // Otherwise you can see:
                 // $ oc label namespace <name> "label1=foo"
                 // Error from server (Forbidden): namespaces "<name>" is forbidden: User "<user>" cannot patch resource "namespaces" in API group "" in the namespace "<name>"
-                OpenShifts.admin().namespaces().withName(openShift.getProject().getMetadata().getName()).edit().editMetadata()
-                        .addToLabels(OpenShift.XTF_MANAGED_LABEL, "true").endMetadata().done();
+                OpenShifts.admin().namespaces().withName(openShift.getProject().getMetadata().getName())
+                        .edit(new Visitor<NamespaceBuilder>() {
+                            @Override
+                            public void visit(NamespaceBuilder builder) {
+                                builder.editMetadata()
+                                        .addToLabels(OpenShift.XTF_MANAGED_LABEL, "true");
+                            }
+                        });
             } catch (KubernetesClientException e) {
                 // We weren't able to assign a label to the new project. Let's just print warning since this information
                 // is not critical to the tests execution. Possible cause for this are insufficient permissions since

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- Dependency version properties -->
         <version.httpclient>4.5.13</version.httpclient>
-        <version.openshift-client>4.13.3</version.openshift-client>
+        <version.openshift-client>5.7.3</version.openshift-client>
         <version.commons-io>2.8.0</version.commons-io>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.commons-compress>1.21</version.commons-compress>


### PR DESCRIPTION
Although there are no API changes in XTF itself, it brings new kubernetes-client which contains many breaking changes. 

fixes #427 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
