### PR TITLE
Simplify usage of `oc apply --filename=...`

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinary.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinary.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,6 +38,49 @@ public class OpenShiftBinary {
 
     public void login(String url, String username, String password) {
         this.execute("login", url, "--insecure-skip-tls-verify=true", "-u", username, "-p", password);
+    }
+
+    /**
+     * Apply configuration file in the specified namespace.
+     * Delegates to `oc apply --filename='sourcepath' --namespace='namespace'`
+     * 
+     * @param sourcePath path to configration file
+     * @param namespace namespace
+     */
+    public void apply(String namespace, String sourcePath) {
+        this.execute("apply", "--namespace=" + namespace, "--filename=" + sourcePath);
+    }
+
+    /**
+     * Apply configuration file. Delegates to `oc apply --filename='sourcepath`
+     * 
+     * @param sourcePath path to configration file
+     */
+    public void apply(String sourcePath) {
+        this.execute("apply", "--filename=" + sourcePath);
+    }
+
+    /**
+     * Apply configuration files in the order they appear in the list
+     * 
+     * @param sourcePaths list of paths to configuration files
+     */
+    public void apply(List<String> sourcePaths) {
+        for (String sourcePath : sourcePaths) {
+            apply(sourcePath);
+        }
+    }
+
+    /**
+     * Apply configuration files in the order they appear in the list, using supplied namespace.
+     * 
+     * @param namespace namespace in which the configuration files should be applied
+     * @param sourcePaths list of paths to configuration files
+     */
+    public void apply(String namespace, List<String> sourcePaths) {
+        for (String sourcePath : sourcePaths) {
+            apply(namespace, sourcePath);
+        }
     }
 
     public void project(String projectName) {


### PR DESCRIPTION
Common workflow is applying config files to setup pods. This PR aims to simplify applying (mutliple) config files.

Code snippet example now in use (we have some variations on this in EAP OpenShift testsuite)
```java
		for (String yaml : Arrays.asList(
				"bundle.yaml",
				"prometheus-service-account.yaml",   
				"prometheus-cluster-role.yaml", 
				"prometheus-cluster-role-binding.yaml", 
				"prometheus.yaml"
		)) {
			String absolutePath = String.format("%s/%s", tmpDir, yaml);
			OpenShiftBinaryClient.getInstance().executeCommand("oc apply failed for : " + absolutePath,
						"apply",
						"-f",
						absolutePath);
			}
		}
	}
```

Could be simplified to
```java
		List<String> absolutePaths = Stream.of(
				"bundle.yaml", 
				"prometheus-service-account.yaml",
				"prometheus-cluster-role.yaml",  
				"prometheus-cluster-role-binding.yaml",
				"prometheus.yaml"
		)
				.map((yaml) -> String.format("%s/%s", tmpDir, yaml))
				.collect(Collectors.toList());
		openShiftBinary.apply(absolutePaths);
```


Please make sure your PR meets the following requirements:
- [ ] Pull Request contains a description of the changes
- [ ] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented
