### PR TITLE
[#456][#462] refactor logic determining cluster version and logic downloading oc binar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -72,6 +72,12 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,12 +66,23 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<xtf.global_test_properties.path>${project.basedir}/src/test/resources/global-test.properties</xtf.global_test_properties.path>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
@@ -8,6 +8,7 @@ public final class OpenShiftConfig {
     public static final String OPENSHIFT_VERSION = "xtf.openshift.version";
     public static final String OPENSHIFT_NAMESPACE = "xtf.openshift.namespace";
     public static final String OPENSHIFT_BINARY_PATH = "xtf.openshift.binary.path";
+    public static final String OPENSHIFT_BINARY_URL_CHANNEL = "xtf.openshift.binary.url.channel";
     public static final String OPENSHIFT_BINARY_CACHE_ENABLED = "xtf.openshift.binary.cache.enabled";
     public static final String OPENSHIFT_BINARY_CACHE_PATH = "xtf.openshift.binary.cache.path";
     public static final String OPENSHIFT_BINARY_CACHE_DEFAULT_FOLDER = "xtf-oc-cache";
@@ -53,6 +54,17 @@ public final class OpenShiftConfig {
 
     public static String binaryPath() {
         return XTFConfig.get(OPENSHIFT_BINARY_PATH);
+    }
+
+    /**
+     * Channel configuration for download of OpenShift client from
+     * https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
+     * Channels are: stable, latest, fast, candidate
+     * 
+     * @return channel as configured in xtf.openshift.binary.url.channel property, or default 'stable'
+     */
+    public static String binaryUrlChannelPath() {
+        return XTFConfig.get(OPENSHIFT_BINARY_URL_CHANNEL, "stable");
     }
 
     public static boolean isBinaryCacheEnabled() {

--- a/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
@@ -1,0 +1,131 @@
+package cz.xtf.core.openshift;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.dmr.ModelNode;
+
+import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.http.Https;
+import cz.xtf.core.http.HttpsException;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.ClusterVersion;
+import io.fabric8.openshift.api.model.ClusterVersionList;
+import io.fabric8.openshift.client.OpenShiftHandlers;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class ClusterVersionInfo {
+    // version must be in format major.minor.micro (4.8.13) or major.minor (4.8)
+    private static final Pattern versionPattern = Pattern.compile("^(\\d+\\.\\d+)(\\.\\d+)?$");
+    private final String openshiftVersion;
+    private final Matcher versionMatcher;
+
+    ClusterVersionInfo() {
+        if (StringUtils.isNotEmpty(OpenShiftConfig.version())) {
+            // manually configured version in config
+            openshiftVersion = OpenShiftConfig.version();
+        } else {
+            // try to detect version from cluster
+            openshiftVersion = detectClusterVersionFromCluster();
+        }
+
+        versionMatcher = openshiftVersion != null ? validateConfiguredVersion(openshiftVersion) : null;
+    }
+
+    /**
+     * @return full version of OpenShift cluster as detected or configured or null
+     */
+    String getOpenshiftVersion() {
+        return openshiftVersion;
+    }
+
+    /**
+     * @return major.minor only version of OpenShift cluster as detected or configured or null
+     */
+    String getMajorMinorOpenshiftVersion() {
+        if (openshiftVersion != null) {
+            return versionMatcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * @return true if version is in major.minor format only, false if not valid url
+     */
+    boolean isMajorMinorOnly() {
+        if (openshiftVersion != null) {
+            return versionMatcher.group(2) == null;
+        }
+        return false;
+    }
+
+    /**
+     * @return true if version is in major.minor.micro format, false if not valid url
+     */
+    boolean isMajorMinorMicro() {
+        if (openshiftVersion != null) {
+            return versionMatcher.group(2) != null;
+        }
+        return false;
+    }
+
+    /**
+     * Detects cluster version from cluster
+     * 
+     * @return version of OpenShift cluster or null
+     */
+    private String detectClusterVersionFromCluster() {
+        String openshiftVersion = null;
+        try {
+            // try to access version info on OpenShift 3.x, this endpoint isn't available on OpenShift 4.x
+            // another option might be client.getVersion() but it returns Kubernetes version, we would
+            // need to check whether version starts with 1.x == Kubernetes == OpenShift 4.x
+            //
+            // Response looks like this:
+            //  {
+            //    "major": "3",
+            //    "minor": "11+",
+            //    "gitVersion": "v3.11.272",
+            //    "gitCommit": "8b0575fb48",
+            //    "gitTreeState": "",
+            //    "buildDate": "2020-08-18T05:38:34Z",
+            //    "goVersion": "",
+            //    "compiler": "",
+            //    "platform": ""
+            //  }
+            String versionInfo = Https.httpsGetContent(OpenShiftConfig.url() + "/version/openshift");
+
+            // it is OpenShift 3, parse version from gitVersion and convert it
+            // example: v3.11.272 -> 3.11.272
+            openshiftVersion = ModelNode.fromJSONString(versionInfo).get("gitVersion").asString()
+                    .replaceAll("^v(.*)", "$1");
+        } catch (HttpsException he) {
+            // it is OpenShift 4+
+            // admin is required for operation
+            try {
+                NonNamespaceOperation<ClusterVersion, ClusterVersionList, Resource<ClusterVersion>> op = OpenShiftHandlers
+                        .getOperation(ClusterVersion.class, ClusterVersionList.class, OpenShifts.admin().getHttpClient(),
+                                OpenShifts.admin().getConfiguration());
+                openshiftVersion = op.withName("version").get().getStatus().getDesired().getVersion();
+            } catch (KubernetesClientException kce) {
+                log.warn("xtf.openshift.version isn't configured and automatic version detection failed.", kce);
+            }
+        }
+        return openshiftVersion;
+    }
+
+    private Matcher validateConfiguredVersion(final String version) {
+        Objects.requireNonNull(version);
+
+        Matcher matcher = versionPattern.matcher(version);
+        if (!matcher.matches()) {
+            log.warn("Version {} configured in xtf.openshift.version isn't in expected format 'major.minor[.micro]'.", version);
+        }
+        return matcher;
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfoFactory.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfoFactory.java
@@ -1,0 +1,20 @@
+package cz.xtf.core.openshift;
+
+enum ClusterVersionInfoFactory {
+    INSTANCE;
+
+    private volatile ClusterVersionInfo clusterVersionInfo;
+
+    public ClusterVersionInfo getClusterVersionInfo() {
+        ClusterVersionInfo localRef = clusterVersionInfo;
+        if (localRef == null) {
+            synchronized (ClusterVersionInfoFactory.class) {
+                localRef = clusterVersionInfo;
+                if (localRef == null) {
+                    clusterVersionInfo = localRef = new ClusterVersionInfo();
+                }
+            }
+        }
+        return localRef;
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/ClusterVersionOpenShiftBinaryPathResolver.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ClusterVersionOpenShiftBinaryPathResolver.java
@@ -1,0 +1,235 @@
+package cz.xtf.core.openshift;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.http.Https;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.api.model.Route;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class ClusterVersionOpenShiftBinaryPathResolver implements OpenShiftBinaryPathResolver {
+    private static final String OCP3_CLIENTS_URL = "https://mirror.openshift.com/pub/openshift-v3/clients";
+    private static final String OCP4_CLIENTS_URL = "https://mirror.openshift.com/pub/openshift-v4";
+
+    @Override
+    public String resolve() {
+        final ClusterVersionInfo clusterVersionInfo = ClusterVersionInfoFactory.INSTANCE.getClusterVersionInfo();
+        final boolean cacheEnabled = OpenShiftConfig.isBinaryCacheEnabled();
+
+        final String clientUrl = determineClientUrl(clusterVersionInfo);
+        final Path archivePath = getCachedOrDownloadClientArchive(clientUrl,
+                clusterVersionInfo.getOpenshiftVersion() != null ? getVersionOrChannel(clusterVersionInfo) : "unknown",
+                cacheEnabled);
+        return unpackOpenShiftClientArchive(archivePath, !cacheEnabled);
+    }
+
+    private String determineClientUrl(final ClusterVersionInfo versionInfo) {
+        log.debug("Trying to determine OpenShift client url for cluster version {}.", versionInfo.getOpenshiftVersion());
+        if (versionInfo.getOpenshiftVersion() != null) {
+            return getClientUrlBasedOnOcpVersion(versionInfo);
+        }
+        return loadOrGuessClientUrlOnCluster();
+    }
+
+    private String getClientUrlBasedOnOcpVersion(final ClusterVersionInfo versionInfo) {
+        Objects.requireNonNull(versionInfo);
+
+        if (versionInfo.getOpenshiftVersion().startsWith("3")) {
+            // OpenShift 3
+            return String.format("%s/%s/%s/oc.tar.gz", OCP3_CLIENTS_URL, versionInfo.getOpenshiftVersion(),
+                    getSystemTypeForOCP3());
+        } else {
+            // OpenShift 4
+
+            // https://mirror.openshift.com/pub/openshift-v4/clients/oc/$__DEPRECATED_LOCATION__PLEASE_READ__.txt
+            // Please direct x86_64 users and automation to the new oc client locations under: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
+            //
+            // This directory contains subdirectories for:
+            // - The clients for released version of OpenShift v4; e.g.
+            //   - The clients for OpenShift release 4.6.4: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.6.4/
+            // - The latest client for a given OpenShift update channel; e.g.
+            //   - The latest in the 4.6 candidate channel: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/candidate-4.6/
+            //   - The latest in the 4.5 stable channel: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.5/
+            // - The latest client for the channels of the latest GA OpenShift release.
+            //   - The latest client for the most recent GA release's candidate channel: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/candidate/
+            //   - The latest client for the most recent GA release's stable channel: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
+            //
+            // If you are looking for the latest stable release's client, please use: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
+
+            String ocFileName = SystemUtils.IS_OS_MAC ? "openshift-client-mac.tar.gz" : "openshift-client-linux.tar.gz";
+
+            return String.format("%s/%s/clients/ocp/%s/%s", OCP4_CLIENTS_URL, getSystemTypeForOCP4(),
+                    getVersionOrChannel(versionInfo),
+                    ocFileName);
+        }
+    }
+
+    /**
+     * Generates the URL reading from 'downloads' route in 'openshift-console' namespace
+     * adding OS architecture and OS system to create the full OC client download URL
+     *
+     * @return client url on cluster
+     */
+    private String loadOrGuessClientUrlOnCluster() {
+        final String locationTemplate = "https://%s/%s/%s/oc.tar";
+        final String systemType = getSystemTypeForOCP4();
+        final String operatingSystem = SystemUtils.IS_OS_MAC ? "mac" : "linux";
+
+        try {
+            final Optional<Route> downloadsRouteOptional = Optional
+                    .ofNullable(OpenShifts.admin("openshift-console").getRoute("downloads"));
+            final Route downloads = downloadsRouteOptional
+                    .orElseThrow(() -> new IllegalStateException("We are not able to find download link for OC binary."));
+            return String.format(locationTemplate,
+                    downloads.getSpec().getHost(),
+                    getSystemTypeForOCP4(),
+                    operatingSystem);
+        } catch (KubernetesClientException kce) {
+            log.warn(
+                    "It isn't possible to read 'downloads' route in 'openshift-console' namespace to get binary location. Attempting to guess it.",
+                    kce);
+            // try to guess URL in case of insufficient permission to read route 'downloads' in 'openshift-console' namespace
+            return String.format(locationTemplate,
+                    OpenShifts.admin("openshift-console").generateHostname("downloads"),
+                    systemType,
+                    operatingSystem);
+        }
+    }
+
+    private Path getCachedOrDownloadClientArchive(final String url, final String version, final boolean cacheEnabled) {
+        Objects.requireNonNull(url);
+
+        log.debug("Trying to load OpenShift client archive from cache (enabled: {}) or download it from {}.", cacheEnabled,
+                url);
+        Path archivePath;
+        if (cacheEnabled) {
+            Path cachePath = Paths.get(OpenShiftConfig.binaryCachePath(), version, DigestUtils.md5Hex(url));
+            archivePath = cachePath.resolve("oc.tar.gz");
+            if (Files.exists(archivePath)) {
+                // it is cached, removed immediately
+                log.debug("OpenShift client archive is already in cache: {}.", archivePath.toAbsolutePath());
+                return archivePath;
+            }
+            log.debug("OpenShift client archive not found in cache, downloading it.");
+        } else {
+            archivePath = getProjectOcDir().resolve("oc.tar.gz");
+            log.debug("Cache is disabled, downloading OpenShift client archive to {}.", archivePath.toAbsolutePath());
+        }
+
+        try {
+            Https.copyHttpsURLToFile(url, archivePath.toFile(), 20_000, 300_000);
+        } catch (IOException ioe) {
+            throw new IllegalStateException("Failed to download and extract oc binary from " + url, ioe);
+        }
+        return archivePath;
+    }
+
+    private String unpackOpenShiftClientArchive(final Path archivePath, final boolean deleteArchiveWhenDone) {
+        Objects.requireNonNull(archivePath);
+
+        try {
+            List<String> args = Stream
+                    .of("tar", "-xf", archivePath.toAbsolutePath().toString(), "-C",
+                            getProjectOcDir().toAbsolutePath().toString())
+                    .collect(Collectors.toList());
+            ProcessBuilder pb = new ProcessBuilder(args);
+
+            pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+            int result = pb.start().waitFor();
+
+            if (result != 0) {
+                throw new IOException("Failed to execute: " + args);
+            }
+
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException("Failed to extract oc binary " + archivePath.toAbsolutePath(), e);
+        }
+
+        try {
+            if (deleteArchiveWhenDone) {
+                Files.delete(archivePath);
+            }
+        } catch (IOException ioe) {
+            log.warn("It wasn't possible to delete OpenShift client archive {}", archivePath.toAbsolutePath(), ioe);
+        }
+
+        return getProjectOcDir().resolve("oc").toAbsolutePath().toString();
+    }
+
+    private String getSystemTypeForOCP3() {
+        String systemType = "linux";
+        if (SystemUtils.IS_OS_MAC) {
+            systemType = "macosx";
+        } else if (isS390x()) {
+            systemType += "-s390x";
+        } else if (isPpc64le()) {
+            systemType += "-ppc64le";
+        }
+        return systemType;
+    }
+
+    private String getSystemTypeForOCP4() {
+        String systemType = "amd64";
+        if (isS390x()) {
+            systemType = "s390x";
+        } else if (isPpc64le()) {
+            systemType = "ppc64le";
+        }
+        return systemType;
+    }
+
+    private static boolean isS390x() {
+        return SystemUtils.IS_OS_ZOS || "s390x".equals(SystemUtils.OS_ARCH) || SystemUtils.OS_VERSION.contains("s390x");
+    }
+
+    private static boolean isPpc64le() {
+        return "ppc64le".equals(SystemUtils.OS_ARCH) || SystemUtils.OS_VERSION.contains("ppc64le");
+    }
+
+    private Path getProjectOcDir() {
+        Path dir = Paths.get("tmp/oc/");
+
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException ioe) {
+            throw new IllegalStateException("Failed to create directory " + dir.toAbsolutePath(), ioe);
+        }
+
+        return dir;
+    }
+
+    private String getVersionOrChannel(ClusterVersionInfo versionInfo) {
+        Objects.requireNonNull(versionInfo);
+
+        if (versionInfo.isMajorMinorMicro()) {
+            return versionInfo.getOpenshiftVersion();
+        } else {
+            return getConfiguredChannel() + "-" + versionInfo.getMajorMinorOpenshiftVersion();
+        }
+    }
+
+    private String getConfiguredChannel() {
+        final String channel = OpenShiftConfig.binaryUrlChannelPath();
+        // validate
+        if (!Stream.of("stable", "fast", "latest", "candidate").collect(Collectors.toList()).contains(channel)) {
+            throw new IllegalStateException(
+                    "Channel (" + channel + ") configured in 'xtf.openshift.binary.url.channel' property is invalid.");
+        }
+        return channel;
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/ConfiguredPathOpenShiftBinaryResolver.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ConfiguredPathOpenShiftBinaryResolver.java
@@ -1,0 +1,11 @@
+package cz.xtf.core.openshift;
+
+import cz.xtf.core.config.OpenShiftConfig;
+
+class ConfiguredPathOpenShiftBinaryResolver implements OpenShiftBinaryPathResolver {
+
+    @Override
+    public String resolve() {
+        return OpenShiftConfig.binaryPath();
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryManager.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryManager.java
@@ -1,0 +1,114 @@
+package cz.xtf.core.openshift;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+import cz.xtf.core.config.OpenShiftConfig;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class OpenShiftBinaryManager {
+
+    private final String openShiftBinaryPath;
+
+    OpenShiftBinaryManager(final String openShiftBinaryPath) {
+        this.openShiftBinaryPath = openShiftBinaryPath;
+    }
+
+    String getBinaryPath() {
+        return openShiftBinaryPath;
+    }
+
+    OpenShiftBinary masterBinary(String namespace) {
+        Objects.requireNonNull(namespace);
+
+        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.masterUsername(), OpenShiftConfig.masterPassword(),
+                OpenShiftConfig.masterKubeconfig(), namespace);
+    }
+
+    OpenShiftBinary adminBinary(String namespace) {
+        Objects.requireNonNull(namespace);
+
+        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.adminUsername(), OpenShiftConfig.adminPassword(),
+                OpenShiftConfig.adminKubeconfig(), namespace);
+    }
+
+    private OpenShiftBinary getBinary(String token, String username, String password, String kubeconfig,
+            String namespace) {
+        String ocConfigPath = createUniqueOcConfigFolder().resolve("oc.config").toAbsolutePath().toString();
+        OpenShiftBinary openShiftBinary;
+
+        if (StringUtils.isNotEmpty(token) || StringUtils.isNotEmpty(username)) {
+            // If we are using a token or username/password, we start with a nonexisting kubeconfig and do an "oc login"
+            openShiftBinary = new OpenShiftBinary(OpenShifts.getBinaryPath(), ocConfigPath);
+            if (StringUtils.isNotEmpty(token)) {
+                openShiftBinary.login(OpenShiftConfig.url(), token);
+            } else {
+                openShiftBinary.login(OpenShiftConfig.url(), username, password);
+            }
+        } else {
+            // If we are using an existing kubeconfig (or a default kubeconfig), we copy the original kubeconfig
+            if (StringUtils.isNotEmpty(kubeconfig)) {
+                // We copy the specified kubeconfig
+                try {
+                    Files.copy(Paths.get(kubeconfig), Paths.get(ocConfigPath), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                // We copy the default ~/.kube/config
+                File defaultKubeConfig = Paths.get(getHomeDir(), ".kube", "config").toFile();
+                if (defaultKubeConfig.isFile()) {
+                    try {
+                        Files.copy(defaultKubeConfig.toPath(), Paths.get(ocConfigPath), StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    throw new RuntimeException(defaultKubeConfig.getAbsolutePath()
+                            + " does not exist and no other OpenShift master option specified");
+                }
+            }
+            openShiftBinary = new OpenShiftBinary(OpenShifts.getBinaryPath(), ocConfigPath);
+        }
+
+        if (StringUtils.isNotEmpty(namespace)) {
+            openShiftBinary.project(namespace);
+        }
+
+        return openShiftBinary;
+    }
+
+    private Path createUniqueOcConfigFolder() {
+        try {
+            return Files.createTempDirectory(getProjectOcConfigDir(), "config");
+        } catch (IOException e) {
+            throw new IllegalStateException("Temporary folder for oc config couldn't be created", e);
+        }
+    }
+
+    // TODO: this code is duplicated from OpenShifts.getHomeDir
+    // it should be revised together with token management
+    // https://github.com/xtf-cz/xtf/issues/464
+    private static String getHomeDir() {
+        String home = System.getenv("HOME");
+        if (home != null && !home.isEmpty()) {
+            File f = new File(home);
+            if (f.exists() && f.isDirectory()) {
+                return home;
+            }
+        }
+        return System.getProperty("user.home", ".");
+    }
+
+    private Path getProjectOcConfigDir() {
+        return Paths.get("tmp/oc/");
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryManagerFactory.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryManagerFactory.java
@@ -1,0 +1,36 @@
+package cz.xtf.core.openshift;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+enum OpenShiftBinaryManagerFactory {
+    INSTANCE;
+
+    private volatile OpenShiftBinaryManager openShiftBinaryManager;
+
+    OpenShiftBinaryManager getOpenShiftBinaryManager() {
+        OpenShiftBinaryManager localRef = openShiftBinaryManager;
+        if (localRef == null) {
+            synchronized (OpenShiftBinaryManagerFactory.class) {
+                localRef = openShiftBinaryManager;
+                if (localRef == null) {
+                    for (OpenShiftBinaryPathResolver resolver : resolverList()) {
+                        String path = resolver.resolve();
+                        if (path != null) {
+                            openShiftBinaryManager = localRef = new OpenShiftBinaryManager(path);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return localRef;
+    }
+
+    private List<OpenShiftBinaryPathResolver> resolverList() {
+        return Stream.of(
+                new ConfiguredPathOpenShiftBinaryResolver(),
+                new ClusterVersionOpenShiftBinaryPathResolver()).collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryPathResolver.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinaryPathResolver.java
@@ -1,0 +1,9 @@
+package cz.xtf.core.openshift;
+
+interface OpenShiftBinaryPathResolver {
+
+    /**
+     * @return resolved path or null
+     */
+    String resolve();
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
@@ -7,8 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -19,14 +17,10 @@ import javax.net.ssl.HttpsURLConnection;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.SystemUtils;
-import org.jboss.dmr.ModelNode;
 
 import cz.xtf.core.config.OpenShiftConfig;
 import cz.xtf.core.http.Https;
 import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.openshift.api.model.Route;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -36,8 +30,6 @@ public class OpenShifts {
 
     private static OpenShift adminUtil;
     private static OpenShift masterUtil;
-
-    private static volatile String openShiftBinaryPath;
 
     public static OpenShift admin() {
         if (adminUtil == null) {
@@ -88,19 +80,7 @@ public class OpenShifts {
     }
 
     public static String getBinaryPath() {
-        if (openShiftBinaryPath == null) {
-            synchronized (OpenShifts.class) {
-                if (openShiftBinaryPath == null) {
-                    if (OpenShiftConfig.binaryPath() != null) {
-                        openShiftBinaryPath = OpenShiftConfig.binaryPath();
-                    } else {
-                        openShiftBinaryPath = OpenShifts.downloadOpenShiftBinary(OpenShifts.getVersion());
-                    }
-                }
-            }
-        }
-
-        return openShiftBinaryPath;
+        return OpenShiftBinaryManagerFactory.INSTANCE.getOpenShiftBinaryManager().getBinaryPath();
     }
 
     public static OpenShiftBinary masterBinary() {
@@ -108,8 +88,7 @@ public class OpenShifts {
     }
 
     public static OpenShiftBinary masterBinary(String namespace) {
-        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.masterUsername(), OpenShiftConfig.masterPassword(),
-                OpenShiftConfig.masterKubeconfig(), namespace);
+        return OpenShiftBinaryManagerFactory.INSTANCE.getOpenShiftBinaryManager().masterBinary(namespace);
     }
 
     public static OpenShiftBinary adminBinary() {
@@ -117,54 +96,7 @@ public class OpenShifts {
     }
 
     public static OpenShiftBinary adminBinary(String namespace) {
-        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.adminUsername(), OpenShiftConfig.adminPassword(),
-                OpenShiftConfig.adminKubeconfig(), namespace);
-    }
-
-    private static OpenShiftBinary getBinary(String token, String username, String password, String kubeconfig,
-            String namespace) {
-        String ocConfigPath = createUniqueOcConfigFolder().resolve("oc.config").toAbsolutePath().toString();
-        OpenShiftBinary openShiftBinary;
-
-        if (StringUtils.isNotEmpty(token) || StringUtils.isNotEmpty(username)) {
-            // If we are using a token or username/password, we start with a nonexisting kubeconfig and do an "oc login"
-            openShiftBinary = new OpenShiftBinary(OpenShifts.getBinaryPath(), ocConfigPath);
-            if (StringUtils.isNotEmpty(token)) {
-                openShiftBinary.login(OpenShiftConfig.url(), token);
-            } else {
-                openShiftBinary.login(OpenShiftConfig.url(), username, password);
-            }
-        } else {
-            // If we are using an existing kubeconfig (or a default kubeconfig), we copy the original kubeconfig
-            if (StringUtils.isNotEmpty(kubeconfig)) {
-                // We copy the specified kubeconfig
-                try {
-                    Files.copy(Paths.get(kubeconfig), Paths.get(ocConfigPath), StandardCopyOption.REPLACE_EXISTING);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            } else {
-                // We copy the default ~/.kube/config
-                File defaultKubeConfig = Paths.get(getHomeDir(), ".kube", "config").toFile();
-                if (defaultKubeConfig.isFile()) {
-                    try {
-                        Files.copy(defaultKubeConfig.toPath(), Paths.get(ocConfigPath), StandardCopyOption.REPLACE_EXISTING);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                } else {
-                    throw new RuntimeException(defaultKubeConfig.getAbsolutePath()
-                            + " does not exist and no other OpenShift master option specified");
-                }
-            }
-            openShiftBinary = new OpenShiftBinary(OpenShifts.getBinaryPath(), ocConfigPath);
-        }
-
-        if (StringUtils.isNotEmpty(namespace)) {
-            openShiftBinary.project(namespace);
-        }
-
-        return openShiftBinary;
+        return OpenShiftBinaryManagerFactory.INSTANCE.getOpenShiftBinaryManager().adminBinary(namespace);
     }
 
     private static String getHomeDir() {
@@ -178,139 +110,19 @@ public class OpenShifts {
         return System.getProperty("user.home", ".");
     }
 
-    private static String getSystemTypeForOCP3() {
-        String systemType = "linux";
-        if (SystemUtils.IS_OS_MAC) {
-            systemType = "macosx";
-        } else if (isS390x()) {
-            systemType += "-s390x";
-        } else if (isPpc64le()) {
-            systemType += "-ppc64le";
-        }
-        return systemType;
-    }
-
-    private static String getSystemTypeForOCP4() {
-        String systemType = "amd64";
-        if (isS390x()) {
-            systemType = "s390x";
-        } else if (isPpc64le()) {
-            systemType = "ppc64le";
-        }
-        return systemType;
-    }
-
-    private static boolean isPpc64le() {
-        return "ppc64le".equals(SystemUtils.OS_ARCH) || SystemUtils.OS_VERSION.contains("ppc64le");
-    }
-
-    private static boolean isS390x() {
-        return SystemUtils.IS_OS_ZOS || "s390x".equals(SystemUtils.OS_ARCH) || SystemUtils.OS_VERSION.contains("s390x");
-    }
-
-    /**
-     * Creates the URL reading from OCP client mirrors or from the cluster
-     * 
-     * @param version String, OCP version
-     * @return String, the full path of the oc binary client
-     */
-    private static String downloadOpenShiftBinary(String version) {
-
-        final String clientLocation;
-        final String ocFileName;
-
-        if (version.startsWith("3")) {
-            clientLocation = String.format("%s/%s/%s/", OCP3_CLIENTS_URL, version, getSystemTypeForOCP3());
-            ocFileName = "oc.tar.gz";
-        } else {
-            if (StringUtils.isNotEmpty(OpenShiftConfig.version())) {
-                clientLocation = String.format("%s/%s/clients/ocp/%s/", OCP4_CLIENTS_URL, getSystemTypeForOCP4(), version);
-                ocFileName = SystemUtils.IS_OS_MAC ? "openshift-client-mac.tar.gz" : "openshift-client-linux.tar.gz";
-            } else {
-                return downloadClientFromClusterRoute(version);
-            }
-        }
-        return downloadOpenShiftBinaryInternal(version, ocFileName, clientLocation, false);
-    }
-
-    /**
-     * Generates the URL reading from 'downloads' route in 'openshift-console' namespace
-     * adding OS architecture and OS system to create the full OC client download URL
-     * 
-     * @param version String, OCP version
-     * @return String, the path returned by {@link #downloadOpenShiftBinaryInternal(String, String, String, boolean)}
-     */
-    private static String downloadClientFromClusterRoute(String version) {
-
-        final Optional<Route> downloadsRouteOptional = Optional
-                .ofNullable(admin("openshift-console").getRoute("downloads"));
-        final Route downloads = downloadsRouteOptional
-                .orElseThrow(() -> new IllegalStateException("We are not able to find download link for OC binary."));
-        final String clientLocation = String.format("https://" + downloads.getSpec().getHost() + "/%s/%s/",
-                getSystemTypeForOCP4(),
-                SystemUtils.IS_OS_MAC ? "mac" : "linux");
-        return downloadOpenShiftBinaryInternal(version, "oc.tar", clientLocation, true);
-    }
-
-    private static String downloadOpenShiftBinaryInternal(final String version, final String ocFileName,
-            String clientLocation, final boolean trustAll) {
-        int code = Https.httpsGetCode(clientLocation);
-
-        if (version.startsWith("3") && code == 404) {
-            //workaround for ocp 3.11 trying to append "-1" to version to match URL
-            clientLocation = clientLocation.replace(version, version.concat("-1"));
-            code = Https.httpsGetCode(clientLocation);
-        }
-
-        if (code != 200) {
-            throw new IllegalStateException("Client binary for version " + version + " isn't available at " + clientLocation);
-        }
-
-        File workdir = ocBinaryFolder();
-
-        // Download and extract client
-        File ocTarFile = new File(workdir, "oc.tar.gz");
-        File ocFile = new File(workdir, "oc");
-
-        final String ocUrl = clientLocation + ocFileName;
-        try {
-            URL requestUrl = new URL(ocUrl);
-
-            log.info("downloading from {} ", ocUrl);
-
-            File cachedOcTarFile = getOcFromCache(version, ocUrl, ocTarFile);
-
-            if (!OpenShiftConfig.isBinaryCacheEnabled() || !cachedOcTarFile.exists()) {
-                if (trustAll) {
-                    Https.copyHttpsURLToFile(requestUrl, ocTarFile, 20_000, 300_000);
-                } else {
-                    FileUtils.copyURLToFile(requestUrl, ocTarFile, 20_000, 300_000);
-                }
-                saveOcOnCache(version, ocUrl, ocTarFile);
-            } else {
-                FileUtils.copyFile(cachedOcTarFile, ocTarFile);
-            }
-
-            executeCommand("tar", "-xf", ocTarFile.getPath(), "-C", workdir.getPath());
-            FileUtils.deleteQuietly(ocTarFile);
-
-            return ocFile.getAbsolutePath();
-        } catch (IOException | InterruptedException e) {
-            throw new IllegalStateException("Failed to download and extract oc binary from " + ocUrl, e);
-        }
-    }
-
     /**
      * Save oc binary in a folder to use as cache to avoid to download it again.
      * The folder path depends on the OCP version and the download url.
      * The file can be accessed using {@link #getOcFromCache(String, String, File)}.
      * It works only if {@link OpenShiftConfig#isBinaryCacheEnabled()}.
-     * 
+     *
      * @param version String, OCP cluster version.
      * @param ocUrl String, download URL.
      * @param ocTarFile String, workdir file.
      * @throws IOException
+     * @deprecated this should have never been made public, can be removed in future versions. It is not used internally by XTF
      */
+    @Deprecated
     public static void saveOcOnCache(String version, String ocUrl, File ocTarFile) throws IOException {
         if (OpenShiftConfig.isBinaryCacheEnabled()) {
             File cacheRootFile = new File(OpenShiftConfig.binaryCachePath());
@@ -325,17 +137,24 @@ public class OpenShifts {
 
     /**
      * Retrieve the file from the folder populated by {@link #saveOcOnCache(String, String, File)}.
-     * 
+     *
      * @param version String, OCP cluster version.
      * @param ocUrl String, download URL.
      * @param ocTarFile String, workdir file.
      * @return File, reference to the file, if the cache is not populated, the file is not null, but it doesn't exist.
      * @throws IOException
+     * @deprecated this should have never been made public, can be removed in future versions. It is not used internally by XTF
      */
+    @Deprecated
     public static File getOcFromCache(String version, String ocUrl, File ocTarFile) throws IOException {
         return new File(getOcCachePath(version, ocUrl).toFile(), ocTarFile.getName());
     }
 
+    /**
+     * * @deprecated this should have never been made public, can be removed in future versions. It is not used internally by
+     * XTF
+     */
+    @Deprecated
     private static Path getOcCachePath(String version, String ocUrl) {
         return Paths.get(OpenShiftConfig.binaryCachePath(), version, DigestUtils.md5Hex(ocUrl));
     }
@@ -344,33 +163,10 @@ public class OpenShifts {
      * Returns {@link OpenShiftConfig#version()}. If not available then access OpenShift endpoint for a version. Be aware
      * that this operation requires admin role for OpenShift 4 unlike to OpenShift 3.
      *
-     * @return Openshift cluster version
+     * @return Openshift cluster version if configured or detected from cluster, null otherwise
      */
     public static String getVersion() {
-        if (StringUtils.isNotEmpty(OpenShiftConfig.version())) {
-            return OpenShiftConfig.version();
-        }
-        final String ocp3UrlVersion = OpenShiftConfig.url() + "/version/openshift";
-        if (Https.getCode(ocp3UrlVersion) == 200) { // for OCP 3
-            String content = Https.httpsGetContent(ocp3UrlVersion);
-            return ModelNode.fromJSONString(content).get("gitVersion").asString().replaceAll("^v(.*)", "$1");
-        } else { // for OCP version > 3
-            final CustomResourceDefinitionContext crdContext = new CustomResourceDefinitionContext.Builder()
-                    .withGroup("config.openshift.io")
-                    .withPlural("clusterversions")
-                    .withScope("NonNamespaced")
-                    .withVersion("v1")
-                    .build();
-            return toString(toMap(toMap(admin().customResource(crdContext).get("version"), "status"), "desired"), "version");
-        }
-    }
-
-    private static String toString(Object map, String key) {
-        return (String) ((Map) map).get(key);
-    }
-
-    private static Map toMap(Object map, String key) {
-        return (Map) ((Map) map).get(key);
+        return ClusterVersionInfoFactory.INSTANCE.getClusterVersionInfo().getOpenshiftVersion();
     }
 
     public static String getMasterToken() {
@@ -392,7 +188,7 @@ public class OpenShifts {
         if (StringUtils.isNotEmpty(username)) {
             HttpsURLConnection connection = null;
             try {
-                if (OpenShiftConfig.version().startsWith("3")) {
+                if (getVersion() != null && getVersion().startsWith("3")) {
                     connection = Https.getHttpsConnection(new URL(
                             OpenShiftConfig.url()
                                     + "/oauth/authorize?response_type=token&client_id=openshift-challenging-client"));
@@ -445,37 +241,5 @@ public class OpenShifts {
             log.error("Unable to retrieve token from default kubeconfig: {} ", defaultKubeConfig, e);
         }
         return null;
-    }
-
-    private static void executeCommand(String... args) throws IOException, InterruptedException {
-        ProcessBuilder pb = new ProcessBuilder(args);
-
-        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-
-        int result = pb.start().waitFor();
-
-        if (result != 0) {
-            throw new IOException("Failed to execute: " + Arrays.toString(args));
-        }
-    }
-
-    private static Path createUniqueOcConfigFolder() {
-        try {
-            return Files.createTempDirectory(ocBinaryFolder().toPath(), "config");
-        } catch (IOException e) {
-            throw new IllegalStateException("Temporary folder for oc config couldn't be created", e);
-        }
-    }
-
-    private static File ocBinaryFolder() {
-        File workdir = new File(Paths.get("tmp/oc").toAbsolutePath().toString());
-        if (workdir.exists()) {
-            return workdir;
-        }
-        if (!workdir.mkdirs()) {
-            throw new IllegalStateException("Cannot mkdirs " + workdir);
-        }
-        return workdir;
     }
 }

--- a/core/src/test/java/cz/xtf/core/openshift/ClusterVersionInfoTest.java
+++ b/core/src/test/java/cz/xtf/core/openshift/ClusterVersionInfoTest.java
@@ -1,0 +1,29 @@
+package cz.xtf.core.openshift;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClusterVersionInfoTest {
+
+    private ClusterVersionInfo clusterVersionInfo = new ClusterVersionInfo();
+
+    @Test
+    public void getOpenshiftVersionTest() {
+        Assertions.assertEquals("4.8.14", clusterVersionInfo.getOpenshiftVersion());
+    }
+
+    @Test
+    public void getMajorMinorOpenshiftVersionTest() {
+        Assertions.assertEquals("4.8", clusterVersionInfo.getMajorMinorOpenshiftVersion());
+    }
+
+    @Test
+    public void isMajorMinorOnlyTest() {
+        Assertions.assertFalse(clusterVersionInfo.isMajorMinorOnly());
+    }
+
+    @Test
+    public void isMajorMinorMicroTest() {
+        Assertions.assertTrue(clusterVersionInfo.isMajorMinorMicro());
+    }
+}

--- a/core/src/test/java/cz/xtf/core/openshift/ClusterVersionOpenShiftBinaryPathResolverTest.java
+++ b/core/src/test/java/cz/xtf/core/openshift/ClusterVersionOpenShiftBinaryPathResolverTest.java
@@ -1,0 +1,39 @@
+package cz.xtf.core.openshift;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import cz.xtf.core.config.OpenShiftConfig;
+
+public class ClusterVersionOpenShiftBinaryPathResolverTest {
+
+    private OpenShiftBinaryPathResolver resolver = new ClusterVersionOpenShiftBinaryPathResolver();
+
+    @Test
+    public void resolveTest() {
+        String path = resolver.resolve();
+
+        SoftAssertions softAssertions = new SoftAssertions();
+
+        // path is not null
+        softAssertions.assertThat(path).isNotNull();
+
+        // path is correct and binary file exists
+        Path ocPath = Paths.get("tmp/oc/oc");
+        softAssertions.assertThat(path).isEqualTo(ocPath.toAbsolutePath().toString());
+        softAssertions.assertThat(Files.exists((ocPath))).isTrue();
+
+        // archive is in cache
+        String urlHash = DigestUtils.md5Hex(
+                "https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/4.8.14/openshift-client-linux.tar.gz");
+        Path cachedPath = Paths.get(OpenShiftConfig.binaryCachePath(), "4.8.14", urlHash, "oc.tar.gz");
+        softAssertions.assertThat(Files.exists(cachedPath)).isTrue();
+
+        softAssertions.assertAll();
+    }
+}

--- a/core/src/test/java/cz/xtf/core/openshift/ConfiguredPathOpenShiftBinaryResolverTest.java
+++ b/core/src/test/java/cz/xtf/core/openshift/ConfiguredPathOpenShiftBinaryResolverTest.java
@@ -1,0 +1,14 @@
+package cz.xtf.core.openshift;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ConfiguredPathOpenShiftBinaryResolverTest {
+
+    private OpenShiftBinaryPathResolver resolver = new ConfiguredPathOpenShiftBinaryResolver();
+
+    @Test
+    public void resolveTest() {
+        Assertions.assertEquals("/tmp/test", resolver.resolve());
+    }
+}

--- a/core/src/test/java/cz/xtf/core/openshift/OpenShiftBinaryManagerFactoryTest.java
+++ b/core/src/test/java/cz/xtf/core/openshift/OpenShiftBinaryManagerFactoryTest.java
@@ -1,0 +1,14 @@
+package cz.xtf.core.openshift;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OpenShiftBinaryManagerFactoryTest {
+
+    @Test
+    public void getOpenShiftBinaryManagerTest() {
+        OpenShiftBinaryManager openShiftBinaryManager = OpenShiftBinaryManagerFactory.INSTANCE.getOpenShiftBinaryManager();
+        Assertions.assertNotNull(openShiftBinaryManager);
+        Assertions.assertEquals("/tmp/test", openShiftBinaryManager.getBinaryPath());
+    }
+}

--- a/core/src/test/java/cz/xtf/core/openshift/OpenShiftsTest.java
+++ b/core/src/test/java/cz/xtf/core/openshift/OpenShiftsTest.java
@@ -31,12 +31,15 @@ public class OpenShiftsTest {
 
     @AfterEach
     public void clean() throws IOException {
-        final File directory = Paths.get(OpenShiftConfig.binaryCachePath()).toFile();
+        final File directory = Paths.get(OpenShiftConfig.binaryCachePath(), version).toFile();
         if (directory.exists()) {
             FileUtils.deleteDirectory(directory);
         }
     }
 
+    //
+    // methods tested bellow are deprecated
+    //
     @Test
     public void saveOnCacheTest() throws IOException {
         OpenShifts.saveOcOnCache(version, ocUrl, ocTarFile);

--- a/core/src/test/resources/global-test.properties
+++ b/core/src/test/resources/global-test.properties
@@ -1,0 +1,2 @@
+xtf.openshift.binary.path=/tmp/test
+xtf.openshift.version=4.8.14

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <version.commons-compress>1.21</version.commons-compress>
         <version.commons-codec>1.15</version.commons-codec>
         <version.slf4j-api>1.7.30</version.slf4j-api>
+        <version.logback-classic>1.2.6</version.logback-classic>
         <version.rxjava-string>1.1.1</version.rxjava-string>
         <version.rxjava>1.3.8</version.rxjava>
         <version.jboss-dmr>1.3.0.Final</version.jboss-dmr>
@@ -190,6 +191,12 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${version.gson}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${version.logback-classic}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
fixes https://github.com/xtf-cz/xtf/issues/456
fixes https://github.com/xtf-cz/xtf/issues/462

- cache openshift version (loaded either from configuration or from cluster)
- download oc binary from
   - mirror.openshift.com (if cluster version is known)
   - cluster (if version is uknown assume OCP4 and download it from cluster)o
- binary download supports stable (default), latest, candidate and fast channels if configured version is in major.minor format only

Some public methods from `OpenShifts` class are marked as deprecated, they aren't now used internally by XTF and I believe they shouldn't have been public.

Some tests are included, the rest (major.minor only version, no version, no permissions to detect cluster version ...) tested manually.
