### PR TITLE
bump openshift-client to 5.9.0

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -68,11 +68,8 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.base.OperationContext;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.api.model.BuildRequest;
 import io.fabric8.openshift.api.model.BuildRequestBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -88,9 +85,6 @@ import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.fabric8.openshift.client.ParameterValue;
-import io.fabric8.openshift.client.dsl.BuildConfigResource;
-import io.fabric8.openshift.client.dsl.internal.BuildConfigOperationContext;
-import io.fabric8.openshift.client.dsl.internal.build.BuildConfigOperationsImpl;
 import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 import rx.observables.StringObservable;
@@ -818,26 +812,6 @@ public class OpenShift extends DefaultOpenShiftClient {
     }
 
     // BuildConfigs
-
-    // Workaround for NPE:
-    //    java.lang.NullPointerException: unit == null
-    //    at okhttp3.internal.Util.checkDuration(Util.java:496)
-    //    at okhttp3.OkHttpClient$Builder.readTimeout(OkHttpClient.java:596)
-    //    at io.fabric8.openshift.client.dsl.internal.build.BuildConfigOperationsImpl.submitToApiServerWithRequestBody(BuildConfigOperationsImpl.java:283)
-    //    at io.fabric8.openshift.client.dsl.internal.build.BuildConfigOperationsImpl.fromInputStream(BuildConfigOperationsImpl.java:186)
-    //    at io.fabric8.openshift.client.dsl.internal.build.BuildConfigOperationsImpl.fromInputStream(BuildConfigOperationsImpl.java:167)
-    //    at io.fabric8.openshift.client.dsl.internal.build.BuildConfigOperationsImpl.fromInputStream(BuildConfigOperationsImpl.java:72)
-    //    at cz.xtf.core.bm.BinaryBuildFromSources.build(BinaryBuildFromSources.java:60)
-    //    at cz.xtf.core.bm.BuildManager.deploy(BuildManager.java:62)
-    //    at cz.xtf.junit5.listeners.ManagedBuildPrebuilder.testPlanExecutionStarted(ManagedBuildPrebuilder.java:85)
-    //
-    // kubernetes-client issue will be created
-    @Override
-    public MixedOperation<BuildConfig, BuildConfigList, BuildConfigResource<BuildConfig, Void, Build>> buildConfigs() {
-        return new BuildConfigOperationsImpl(new BuildConfigOperationContext().withTimeoutUnit(TimeUnit.MILLISECONDS),
-                new OperationContext().withOkhttpClient(this.httpClient).withConfig(getConfiguration()));
-    }
-
     public BuildConfig createBuildConfig(BuildConfig buildConfig) {
         return buildConfigs().create(buildConfig);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- Dependency version properties -->
         <version.httpclient>4.5.13</version.httpclient>
-        <version.openshift-client>5.7.3</version.openshift-client>
+        <version.openshift-client>5.9.0</version.openshift-client>
         <version.commons-io>2.8.0</version.commons-io>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.commons-compress>1.21</version.commons-compress>


### PR DESCRIPTION
https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md#590-2021-10-14

includes revert of workaround for an issue that was in 5.7.3 (fixes #461)

Results of our TS with this upgrade:
![xtf_000](https://user-images.githubusercontent.com/3784557/138693529-826b0265-2276-4635-9f42-0899f1cb202e.jpg)
Failures are known or expected.
