### PR TITLE
bump openshift-client to 5.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- Dependency version properties -->
         <version.httpclient>4.5.13</version.httpclient>
-        <version.openshift-client>5.9.0</version.openshift-client>
+        <version.openshift-client>5.10.1</version.openshift-client>
         <version.commons-io>2.8.0</version.commons-io>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.commons-compress>1.21</version.commons-compress>


### PR DESCRIPTION
https://github.com/fabric8io/kubernetes-client/blob/master/CHANGELOG.md#5101-2021-11-12

Results of our TS with this upgrade:
![xtf](https://user-images.githubusercontent.com/3784557/144425825-b079a2d0-6e13-4ea5-8b62-b75e6b31994a.jpg)
Failures are known or expected.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x]  Code is self-descriptive and/or documented
