### PR TITLE
bump openshift-client to 5.11.1

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
@@ -109,8 +109,7 @@ class ClusterVersionInfo {
             // admin is required for operation
             try {
                 NonNamespaceOperation<ClusterVersion, ClusterVersionList, Resource<ClusterVersion>> op = OpenShiftHandlers
-                        .getOperation(ClusterVersion.class, ClusterVersionList.class, OpenShifts.admin().getHttpClient(),
-                                OpenShifts.admin().getConfiguration());
+                        .getOperation(ClusterVersion.class, ClusterVersionList.class, OpenShifts.admin());
                 openshiftVersion = op.withName("version").get().getStatus().getDesired().getVersion();
             } catch (KubernetesClientException kce) {
                 log.warn("xtf.openshift.version isn't configured and automatic version detection failed.", kce);

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -186,7 +186,7 @@ public class OpenShift extends DefaultOpenShiftClient {
     public OpenShift(OpenShiftConfig openShiftConfig) {
         super(openShiftConfig);
 
-        appsAPIGroupClient = new AppsAPIGroupClient(httpClient, openShiftConfig);
+        appsAPIGroupClient = new AppsAPIGroupClient(this);
 
         this.waiters = new OpenShiftWaiters(this);
     }

--- a/core/src/main/java/cz/xtf/core/openshift/PodShell.java
+++ b/core/src/main/java/cz/xtf/core/openshift/PodShell.java
@@ -10,7 +10,6 @@ import cz.xtf.core.waiting.WaiterException;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.dsl.ExecListener;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.Response;
 
 @Slf4j
 public class PodShell {
@@ -71,7 +70,7 @@ public class PodShell {
         private final AtomicBoolean executionDone = new AtomicBoolean(false);
 
         @Override
-        public void onOpen(Response response) {
+        public void onOpen() {
             // DO NOTHING
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- Dependency version properties -->
         <version.httpclient>4.5.13</version.httpclient>
-        <version.openshift-client>5.9.0</version.openshift-client>
+        <version.openshift-client>5.11.1</version.openshift-client>
         <version.commons-io>2.8.0</version.commons-io>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.commons-compress>1.21</version.commons-compress>


### PR DESCRIPTION
https://github.com/fabric8io/kubernetes-client/blob/v5.11.1/CHANGELOG.md

Results of our TS with this upgrade:
![xtf](https://user-images.githubusercontent.com/3784557/148234669-7a51d62e-90a5-4144-9fc9-39d90b13382b.jpg)
Failures are known or expected.

supersedes #468 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
