### PR TITLE
Adding support to skip tests based on provided xtf.<product ID>.subId

### DIFF
--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -42,6 +42,13 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
+++ b/junit5/src/main/java/cz/xtf/junit5/annotations/SkipFor.java
@@ -19,7 +19,8 @@ public @interface SkipFor {
     /**
      * Name or regexp pattern matching name of the image. For example "eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*"
      * <p>
-     * Only one of {@code name}, {@code imageMetadataLabelName} and {@code imageMetadataLabelArchitecture} can be presented.
+     * Only one of {@code name}, {@code imageMetadataLabelName}, {@code imageMetadataLabelArchitecture} and
+     * {@code subId} can be presented.
      */
     String name() default "";
 
@@ -27,7 +28,8 @@ public @interface SkipFor {
      * Name or regexp pattern matching name in {@code Docker Labels} in image metadata
      * For example "jboss-eap-7/eap73-openjdk11-openshift-rhel8" or "eap73-openjdk11-.*".
      * <p>
-     * Only one of {@code name}, {@code imageMetadataLabelName} and {@code imageMetadataLabelArchitecture} can be presented.
+     * Only one of {@code name}, {@code imageMetadataLabelName}, {@code imageMetadataLabelArchitecture} and
+     * {@code subId} can be presented.
      */
     String imageMetadataLabelName() default "";
 
@@ -35,9 +37,20 @@ public @interface SkipFor {
      * Architecture or regexp pattern matching architecture in {@code Docker Labels} in image metadata
      * For example "x86_64" or "x86_.*".
      * <p>
-     * Only one of {@code name}, {@code imageMetadataLabelName} and {@code imageMetadataLabelArchitecture} can be presented.
+     * Only one of {@code name}, {@code imageMetadataLabelName}, {@code imageMetadataLabelArchitecture} and
+     * {@code subId} can be presented.
      */
     String imageMetadataLabelArchitecture() default "";
+
+    /**
+     * Name or regexp pattern matching the value of the {@code xtf.<product id>>.subid} XTF property
+     * For example, ".*74.*" will match and skip the annotated test when xtf.eap.subid is set to "74-openjdk11",
+     * "74-openj9-11" or "74".
+     * <p>
+     * Only one of {@code imageMetadataLabelName}, {@code name}, {@code imageMetadataLabelArchitecture} and
+     * {@code subId} can be presented.
+     */
+    String subId() default "";
 
     String image();
 

--- a/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
+++ b/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
@@ -1,0 +1,113 @@
+package cz.xtf.junit5.extensions;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import cz.xtf.junit5.annotations.SkipFor;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+@ExtendWith(SystemStubsExtension.class)
+class SkipForConditionTest {
+
+    @SystemStub
+    private SystemProperties systemProperties;
+
+    @BeforeEach
+    void before() {
+        systemProperties.set("xtf.eap.subid", "74-openjdk11");
+        systemProperties.set("xtf.eap.74-openjdk11.image",
+                "registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap74-openjdk8-openshift-rhel7:7.4.0-6");
+    }
+
+    @SkipFor(image = "eap", name = ".*eap-74.*", reason = "This test is skipped based on the image name.")
+    class WellAnnotatedImageNameBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", imageMetadataLabelName = "centos7/s2i-base-centos7", reason = "This test is skipped based on the image docker labels")
+    class WellAnnotatedImageMetadataLabelBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", imageMetadataLabelArchitecture = "s390x", reason = "This test is skipped based on the image metadata label architecture")
+    class WellAnnotatedImageMetadataLabelArchitectureBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", subId = ".*74.*", reason = "This test is skipped based on the image product subId")
+    class WellAnnotatedSubIdBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", name = ".*eap-xp1.*", imageMetadataLabelName = "centos7/s2i-base-centos7", reason = "This test SHOULD BE skipped based on the image name.")
+    class BadlyAnnotatedImageNameBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", name = ".*eap-xp1.*", imageMetadataLabelName = "centos7/s2i-base-centos7", reason = "This test SHOULD BE skipped based on the image docker labels")
+    class BadlyAnnotatedImageMetadataLabelBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", name = ".*eap-xp4.*", imageMetadataLabelArchitecture = "s390x", reason = "This test SHOULD BE skipped based on the image metadata label architecture")
+    class BadlyAnnotatedImageMetadataLabelArchitectureBasedSkipTest {
+
+    }
+
+    @SkipFor(image = "eap", name = ".*eap-xp1.*", imageMetadataLabelName = "centos7/s2i-base-centos7", subId = ".*74.*", reason = "This test SHOULD BE skipped based on the image product subId")
+    class BadlyAnnotatedSubIdBasedSkipTest {
+
+    }
+
+    @Test
+    void testUniqueCriteriaResolutionOnWellAnnotatedClasses() {
+        Stream<Class> workingClasses = Stream.of(
+                WellAnnotatedImageNameBasedSkipTest.class,
+                WellAnnotatedImageMetadataLabelBasedSkipTest.class,
+                WellAnnotatedImageMetadataLabelArchitectureBasedSkipTest.class,
+                WellAnnotatedSubIdBasedSkipTest.class);
+        workingClasses.forEach(k -> {
+            try {
+                SkipForCondition.resolve((SkipFor) Arrays.stream(k.getAnnotationsByType(SkipFor.class)).findFirst().get());
+            } catch (RuntimeException re) {
+                //  we should be able to do better things here, as for instance using a specific Exception type
+                if (re.getMessage().equals(
+                        "Only one of 'name', 'imageMetadataLabelName', 'imageMetadataLabelArchitecture' and 'subId' can be presented in 'SkipFor' annotation.")) {
+                    Assertions.fail(String.format("No exception is expected when resolving %s \"@SkipFor\" annotation",
+                            k.getSimpleName()));
+                }
+            }
+        });
+    }
+
+    @Test
+    void testUniqueCriteriaResolutionOnBadlyAnnotatedClasses() {
+        Stream<Class> workingClasses = Stream.of(
+                BadlyAnnotatedImageNameBasedSkipTest.class,
+                BadlyAnnotatedImageMetadataLabelBasedSkipTest.class,
+                BadlyAnnotatedImageMetadataLabelArchitectureBasedSkipTest.class,
+                BadlyAnnotatedSubIdBasedSkipTest.class);
+        workingClasses.forEach(k -> {
+            Exception exception = Assertions.assertThrows(RuntimeException.class, () -> SkipForCondition
+                    .resolve((SkipFor) Arrays.stream(k.getAnnotationsByType(SkipFor.class)).findFirst().get()));
+            Assertions.assertEquals(
+                    "Only one of 'name', 'imageMetadataLabelName', 'imageMetadataLabelArchitecture' and 'subId' can be presented in 'SkipFor' annotation.",
+                    exception.getMessage());
+        });
+    }
+
+    @Test
+    void testSubIdBasedSkipForResolution() {
+        ConditionEvaluationResult conditionEvaluationResult = SkipForCondition.resolve(
+                Arrays.stream(WellAnnotatedSubIdBasedSkipTest.class.getAnnotationsByType(SkipFor.class)).findFirst().get());
+        Assertions.assertTrue(conditionEvaluationResult.isDisabled(), "This test should be disabled via \"subId\"");
+    }
+}


### PR DESCRIPTION
This PR is a proposal for adding support for skipping tests based on the `xtf.<productId>.subid` system property, as per the issue below, since WFLY 27 is not so far away...

Tests added as well, using https://mvnrepository.com/artifact/uk.org.webcompere/system-stubs-jupiter/2.0.1 which seems lightweight enough for use in test scope in order to set properties.

CC @mchoma

Fixes #470 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
