### PR TITLE
change test image url and fail on any error in SkipForConditionTest

### DIFF
--- a/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
+++ b/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
@@ -24,7 +24,7 @@ class SkipForConditionTest {
     void before() {
         systemProperties.set("xtf.eap.subid", "74-openjdk11");
         systemProperties.set("xtf.eap.74-openjdk11.image",
-                "registry-proxy.engineering.redhat.com/rh-osbs/jboss-eap-7-eap74-openjdk8-openshift-rhel7:7.4.0-6");
+                "quay.io/wildfly/wildfly-centos7:latest");
     }
 
     @SkipFor(image = "eap", name = ".*eap-74.*", reason = "This test is skipped based on the image name.")
@@ -71,19 +71,16 @@ class SkipForConditionTest {
     void testUniqueCriteriaResolutionOnWellAnnotatedClasses() {
         Stream<Class> workingClasses = Stream.of(
                 WellAnnotatedImageNameBasedSkipTest.class,
-                WellAnnotatedImageMetadataLabelBasedSkipTest.class,
-                WellAnnotatedImageMetadataLabelArchitectureBasedSkipTest.class,
+                // imageMetadataLabelName and imageMetadataLabelArchitecture try to fetch docker metadata, so they require connection to openshift
+                // WellAnnotatedImageMetadataLabelBasedSkipTest.class,
+                // WellAnnotatedImageMetadataLabelArchitectureBasedSkipTest.class,
                 WellAnnotatedSubIdBasedSkipTest.class);
         workingClasses.forEach(k -> {
             try {
                 SkipForCondition.resolve((SkipFor) Arrays.stream(k.getAnnotationsByType(SkipFor.class)).findFirst().get());
             } catch (RuntimeException re) {
-                //  we should be able to do better things here, as for instance using a specific Exception type
-                if (re.getMessage().equals(
-                        "Only one of 'name', 'imageMetadataLabelName', 'imageMetadataLabelArchitecture' and 'subId' can be presented in 'SkipFor' annotation.")) {
-                    Assertions.fail(String.format("No exception is expected when resolving %s \"@SkipFor\" annotation",
-                            k.getSimpleName()));
-                }
+                Assertions.fail(String.format("No exception is expected when resolving %s \"@SkipFor\" annotation",
+                        k.getSimpleName()));
             }
         });
     }


### PR DESCRIPTION
the main intention is to don't leak internal URL, but some checks were disabled because

- both metadata tests pass correctly only when valid kubeconfig is present locally
- they pass incorrectly without kubeconfig because tests ignore any other Exception message than is configured
- WildFly image doesn't have `architecture` label so it can't pass even with valid kubeconfig

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
