### PR TITLE
Add new xtf.openshift.namespace.per.testcase property which will exec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ xtf.foo.v2.version=1.0.3
 
 Retrieving an instance with this metadata: `Produts.resolve("product");`
 
+#### Run test cases in separate namespaces using `xtf.openshift.namespace.per.testcase` property 
+You can enable running each test case in separate namespace by setting `xtf.openshift.namespace.per.testcase=true`. 
+
+Namespace names follow pattern: "`${xtf.openshift.namespace}`-Test_Case_Name". 
+For example for `xtf.openshift.namespace=testnamespace` and test case `org.test.SmokeTest` it will be `testnamespace-SmokeTest`.
+
+You can limit the length of created namespace by `xtf.openshift.namespace.per.testcase.length.limit` property. By default it's `25` chars. If limit is breached then
+test case name in namespace name is hashed to hold the limit. So namespace name would like `testnamespace-s623jd6332`
+
+**Warning - Limitations**
+
+In case that you're using this feature, consuming test suite must follow those rules to avoid unexpected behaviour when using `cz.xtf.core.openshift.OpenShift` instances:
+
+* Do not create static `cz.xtf.core.openshift.OpenShift` variable like: `public static final OpenShift openshift = Openshifts.master()` on class level. 
+The reason is that during initialization of static instances the test case and corresponsing namespace is not known. To avoid unexpected behaviour `RuntimeException` is thrown.
+* Similarly as above do not create `cz.xtf.core.openshift.OpenShift` variables in static blocks or do not initialize other static variables which creates `cz.xtf.core.openshift.OpenShift` instance.
+
 #### Service Logs Streaming (SLS)
 This feature allows for you to stream the services output while the test is running; this way you can see immediately 
 what is happening inside the cluster.
@@ -215,6 +232,7 @@ following information:
 * _**output**_: the base path where the log stream files - one for each executed test class - will be created. 
   **OPTIONAL**, if not assigned, logs will be streamed to `System.out`. When assigned, XTF will attempt to create the 
   path in case it doesn't exist and default to `System.out` should any error occur. 
+
 
 ###### Usage examples 
 Given what above, enabling SLS for all test classes is possible by executing the following command: 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -78,6 +78,11 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -28,7 +28,7 @@ public class BuildManager {
                 // Otherwise you can see:
                 // $ oc label namespace <name> "label1=foo"
                 // Error from server (Forbidden): namespaces "<name>" is forbidden: User "<user>" cannot patch resource "namespaces" in API group "" in the namespace "<name>"
-                OpenShifts.admin().namespaces().withName(openShift.getNamespace())
+                OpenShifts.admin(openShift.getNamespace()).namespaces().withName(openShift.getNamespace())
                         .edit(new Visitor<NamespaceBuilder>() {
                             @Override
                             public void visit(NamespaceBuilder builder) {

--- a/core/src/main/java/cz/xtf/core/bm/BuildManagers.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManagers.java
@@ -1,7 +1,9 @@
 package cz.xtf.core.bm;
 
+import static cz.xtf.core.config.OpenShiftConfig.OPENSHIFT_NAMESPACE;
+
 import cz.xtf.core.config.BuildManagerConfig;
-import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -23,7 +25,7 @@ public class BuildManagers {
                     bm = new BuildManager(OpenShifts.master(buildNamespace));
 
                     // If the build namespace is in a separate namespace to "master" namespace, we assume it is a shared namespace
-                    if (!BuildManagerConfig.namespace().equals(OpenShiftConfig.namespace())) {
+                    if (!BuildManagerConfig.namespace().equals(XTFConfig.get(OPENSHIFT_NAMESPACE))) {
                         OpenShift admin = OpenShifts.admin(buildNamespace);
 
                         try {

--- a/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
@@ -2,6 +2,11 @@ package cz.xtf.core.config;
 
 import java.nio.file.Paths;
 
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public final class OpenShiftConfig {
     public static final String OPENSHIFT_URL = "xtf.openshift.url";
     public static final String OPENSHIFT_TOKEN = "xtf.openshift.token";
@@ -22,6 +27,19 @@ public final class OpenShiftConfig {
     public static final String OPENSHIFT_MASTER_TOKEN = "xtf.openshift.master.token";
     public static final String OPENSHIFT_ROUTE_DOMAIN = "xtf.openshift.route_domain";
     public static final String OPENSHIFT_PULL_SECRET = "xtf.openshift.pullsecret";
+    public static final String OPENSHIFT_NAMESPACE_PER_TESTCASE = "xtf.openshift.namespace.per.testcase";
+    /**
+     * Used only if xtf.openshift.namespace.per.testcase=true - this property can configure its maximum length. This is useful
+     * in case
+     * where namespace is used in first part of URL of route which must have <64 chars length.
+     */
+    public static final String OPENSHIFT_UNIQUE_NAMESPACE_NAME_LENGTH_LIMIT = "xtf.openshift.namespace.per.testcase.length.limit";
+
+    /**
+     * Used only if xtf.openshift.namespace.per.testcase=true - this property configures default maximum length of namespace
+     * name.
+     */
+    private static final String OPENSHIFT_UNIQUE_NAMESPACE_NAME_LENGTH_LIMIT_DEFAULT = "25";
 
     public static String url() {
         return XTFConfig.get(OPENSHIFT_URL);
@@ -48,8 +66,47 @@ public final class OpenShiftConfig {
         return XTFConfig.get(OPENSHIFT_VERSION);
     }
 
+    /**
+     * @return Returns default namespace as defined in xtf.openshift.namespace property or namespace for currently running test
+     *         case when:
+     *         -Dxtf.openshift.namespace.per.testcase=true.
+     *         In case when current thread does not have associated test case (for example when initializing Openshift instance
+     *         in static variable or static block) then exception is thrown.
+     */
     public static String namespace() {
-        return XTFConfig.get(OPENSHIFT_NAMESPACE);
+        if (useNamespacePerTestcase()) {
+            String namespace = TestCaseContext.getRunningTestcase().get(TestCaseContext.getTestCaseForCurrentThread());
+            if (StringUtils.isEmpty(namespace)) {
+                throw new RuntimeException(
+                        "There is no namespace associated with current thread or test case. This can happen in case that OpenShift instance is created in static variable. In this case avoid using static. Or in thread which is not associated with any test case.");
+            }
+            return namespace;
+        } else {
+            return XTFConfig.get(OPENSHIFT_NAMESPACE);
+        }
+    }
+
+    public static boolean useNamespacePerTestcase() {
+        if (StringUtils.isEmpty(XTFConfig.get(OpenShiftConfig.OPENSHIFT_NAMESPACE_PER_TESTCASE))
+                || (StringUtils.isNotEmpty(XTFConfig.get(OpenShiftConfig.OPENSHIFT_NAMESPACE_PER_TESTCASE))
+                        && !Boolean.parseBoolean(XTFConfig.get(OpenShiftConfig.OPENSHIFT_NAMESPACE_PER_TESTCASE)))) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * @return limit on namespace if it's set by -Dxtf.openshift.unique.namespace.name.length.limit property otherwise returns
+     *         -1 which means not set
+     */
+    public static int getNamespaceLengthLimitForUniqueNamespacePerTest() {
+        if (useNamespacePerTestcase()) {
+            return Integer.parseInt(XTFConfig.get(OPENSHIFT_UNIQUE_NAMESPACE_NAME_LENGTH_LIMIT,
+                    OPENSHIFT_UNIQUE_NAMESPACE_NAME_LENGTH_LIMIT_DEFAULT));
+        } else {
+            return -1;
+        }
     }
 
     public static String binaryPath() {
@@ -60,7 +117,7 @@ public final class OpenShiftConfig {
      * Channel configuration for download of OpenShift client from
      * https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
      * Channels are: stable, latest, fast, candidate
-     * 
+     *
      * @return channel as configured in xtf.openshift.binary.url.channel property, or default 'stable'
      */
     public static String binaryUrlChannelPath() {

--- a/core/src/main/java/cz/xtf/core/config/TestCaseContext.java
+++ b/core/src/main/java/cz/xtf/core/config/TestCaseContext.java
@@ -1,0 +1,47 @@
+package cz.xtf.core.config;
+
+import static cz.xtf.core.config.OpenShiftConfig.OPENSHIFT_NAMESPACE;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestCaseContext {
+
+    /**
+     * Used only in case when test cases are executed in different namespaces when:
+     * -Dxtf.openshift.namespace.per.testcase=true
+     *
+     * This allows to track currently running test case for correct namespace mapping. This is used to automatically find
+     * namespace for running test case when
+     * creating {@link cz.xtf.core.openshift.OpenShift} instances.
+     */
+    private static String TEST_CASE_NAME;
+
+    private static final Map<String, String> testcaseToNamespaceMap = new HashMap<String, String>() {
+        {
+            // put default namespace into map to guarantee that it will be deleted with other namespaces
+            put(XTFConfig.get(OPENSHIFT_NAMESPACE), XTFConfig.get(OPENSHIFT_NAMESPACE));
+        }
+    };
+
+    /**
+     * @return test case name associated with current thread or null if not such mapping exists
+     */
+    public static String getTestCaseForCurrentThread() {
+        return TEST_CASE_NAME;
+    }
+
+    public static void setRunningTestCase(String currentlyRunningTestCaseName) {
+        TEST_CASE_NAME = currentlyRunningTestCaseName;
+    }
+
+    /**
+     * Used only in case when test cases are executed in parallel in different namespaces when:
+     * -Dxtf.openshift.namespace.per.testcase=true
+     *
+     * Maps testcase name -> namespace
+     */
+    public static Map<String, String> getRunningTestcase() {
+        return testcaseToNamespaceMap;
+    }
+}

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShifts.java
@@ -28,14 +28,10 @@ public class OpenShifts {
     private static final String OCP3_CLIENTS_URL = "https://mirror.openshift.com/pub/openshift-v3/clients";
     private static final String OCP4_CLIENTS_URL = "https://mirror.openshift.com/pub/openshift-v4";
 
-    private static OpenShift adminUtil;
-    private static OpenShift masterUtil;
-
     public static OpenShift admin() {
-        if (adminUtil == null) {
-            adminUtil = OpenShifts.admin(OpenShiftConfig.namespace());
-        }
-        return adminUtil;
+
+        return OpenShifts.admin(OpenShiftConfig.namespace());
+
     }
 
     public static OpenShift admin(String namespace) {
@@ -56,10 +52,9 @@ public class OpenShifts {
     }
 
     public static OpenShift master() {
-        if (masterUtil == null) {
-            masterUtil = OpenShifts.master(OpenShiftConfig.namespace());
-        }
-        return masterUtil;
+
+        return OpenShifts.master(OpenShiftConfig.namespace());
+
     }
 
     public static OpenShift master(String namespace) {

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeAllCallback.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeAllCallback.java
@@ -3,14 +3,12 @@ package cz.xtf.junit5.extensions;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 
 public class CleanBeforeAllCallback implements BeforeAllCallback {
-    private static final OpenShift openShift = OpenShifts.master();
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        openShift.clean().waitFor();
+        OpenShifts.master().clean().waitFor();
     }
 }

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeEachCallback.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/CleanBeforeEachCallback.java
@@ -5,12 +5,18 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CleanBeforeEachCallback implements BeforeEachCallback {
-    private static final OpenShift openShift = OpenShifts.master();
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        openShift.clean().waitFor();
+        OpenShift openShift = OpenShifts.master();
+        openShift.clean().reason("Cleaning namespace: " + openShift.getNamespace() + " before test.")
+                .onTimeout(() -> log.info("Cleaning namespace: " + openShift.getNamespace() + " before test - timed out."))
+                .onFailure(() -> log.info("Cleaning namespace: " + openShift.getNamespace() + " before test - failed."))
+                .onSuccess(() -> log.info("Cleaning namespace: " + openShift.getNamespace() + " before test - finished."))
+                .waitFor();
     }
 }

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/ServiceLogsStreamingRunner.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/ServiceLogsStreamingRunner.java
@@ -52,7 +52,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ServiceLogsStreamingRunner implements BeforeAllCallback, AfterAllCallback {
-    private static final OpenShift openShift = OpenShifts.master();
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create("cz", "xtf", "junit",
             "extensions", "ServiceLogsRunner");
 
@@ -247,6 +246,7 @@ public class ServiceLogsStreamingRunner implements BeforeAllCallback, AfterAllCa
         ServiceLogs serviceLogs;
 
         // namespaces
+        OpenShift openShift = OpenShifts.master();
         final String masterNamespace = openShift.getNamespace();
         final String buildsNamespace = BuildManagers.get().openShift().getNamespace();
         final List<String> uniqueNamespaces = new ArrayList<>();

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/SkipForCondition.java
@@ -1,5 +1,7 @@
 package cz.xtf.junit5.extensions;
 
+import static cz.xtf.core.config.OpenShiftConfig.OPENSHIFT_NAMESPACE;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -16,7 +18,9 @@ import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.junit5.annotations.SkipFor;
 import cz.xtf.junit5.annotations.SkipFors;
 import cz.xtf.junit5.model.DockerImageMetadata;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class SkipForCondition implements ExecutionCondition {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -49,10 +53,12 @@ public class SkipForCondition implements ExecutionCondition {
         if (!skipFor.name().equals("")) {
             matcher = Pattern.compile(skipFor.name()).matcher(image.getRepo());
         } else if (!skipFor.imageMetadataLabelName().equals("")) {
-            DockerImageMetadata metadata = DockerImageMetadata.get(OpenShifts.master(), image);
+            DockerImageMetadata metadata = DockerImageMetadata.get(OpenShifts.master(XTFConfig.get(OPENSHIFT_NAMESPACE)),
+                    image);
             matcher = Pattern.compile(skipFor.imageMetadataLabelName()).matcher(metadata.labels().get("name"));
         } else if (!skipFor.imageMetadataLabelArchitecture().equals("")) {
-            DockerImageMetadata metadata = DockerImageMetadata.get(OpenShifts.master(), image);
+            DockerImageMetadata metadata = DockerImageMetadata.get(OpenShifts.master(XTFConfig.get(OPENSHIFT_NAMESPACE)),
+                    image);
             matcher = Pattern.compile(skipFor.imageMetadataLabelArchitecture()).matcher(metadata.labels().get("architecture"));
         } else {
             matcher = Pattern.compile(skipFor.subId()).matcher(XTFConfig.get("xtf." + skipFor.image() + ".subid"));

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
@@ -1,12 +1,28 @@
 package cz.xtf.junit5.listeners;
 
+import static cz.xtf.core.config.OpenShiftConfig.OPENSHIFT_NAMESPACE;
+
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor;
+import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestPlan;
 
 import cz.xtf.core.config.OpenShiftConfig;
+import cz.xtf.core.config.TestCaseContext;
+import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.SimpleWaiter;
@@ -17,12 +33,49 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ProjectCreator implements TestExecutionListener {
-    private static final OpenShift openShift = OpenShifts.master();
+public class ProjectCreator
+        implements TestExecutionListener, BeforeAllCallback, BeforeEachCallback, AfterAllCallback, PostDiscoveryFilter {
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
+        createProject(XTFConfig.get(OPENSHIFT_NAMESPACE));
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        if (OpenShiftConfig.useNamespacePerTestcase()) {
+            setTestExecutionContext(context);
+
+            log.info("BeforeAll - Test case: " + context.getTestClass().get().getName() + " running in thread name: "
+                    + Thread.currentThread().getName()
+                    + " will use namespace: " + OpenShifts.master().getNamespace() + " - thread context is: "
+                    + TestCaseContext.getTestCaseForCurrentThread());
+            createProject(OpenShiftConfig.namespace());
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        // in case that tests in test case are executed in parallel in different threads set the test case thread for each of them
+        if (OpenShiftConfig.useNamespacePerTestcase()) {
+            setTestExecutionContext(context);
+            log.debug("BeforeEach - Test case: " + context.getTestClass().get().getName() + "#"
+                    + context.getTestMethod().get().getName() + " running in thread name: "
+                    + Thread.currentThread().getName()
+                    + " will use namespace: " + OpenShifts.master().getNamespace() + " - thread context is: "
+                    + TestCaseContext.getTestCaseForCurrentThread());
+        }
+    }
+
+    private void setTestExecutionContext(ExtensionContext context) {
+        TestCaseContext.setRunningTestCase(context.getTestClass().get().getName());
+    }
+
+    private void createProject(String namespace) {
+        OpenShift openShift = OpenShifts.master(namespace);
+
         if (openShift.getProject() == null) {
+            log.info("Creating namespace: " + openShift.getNamespace());
             openShift.createProjectRequest();
             openShift.waiters().isProjectReady().waitFor();
 
@@ -33,7 +86,7 @@ public class ProjectCreator implements TestExecutionListener {
                 // Otherwise you can see:
                 // $ oc label namespace <name> "label1=foo"
                 // Error from server (Forbidden): namespaces "<name>" is forbidden: User "<user>" cannot patch resource "namespaces" in API group "" in the namespace "<name>"
-                OpenShifts.admin().namespaces().withName(openShift.getProject().getMetadata().getName())
+                OpenShifts.admin(namespace).namespaces().withName(openShift.getProject().getMetadata().getName())
                         .edit(new Visitor<NamespaceBuilder>() {
                             @Override
                             public void visit(NamespaceBuilder builder) {
@@ -53,17 +106,71 @@ public class ProjectCreator implements TestExecutionListener {
         if (OpenShiftConfig.pullSecret() != null) {
             openShift.setupPullSecret(OpenShiftConfig.pullSecret());
         }
+        log.info("Created namespace: " + openShift.getNamespace());
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (OpenShiftConfig.useNamespacePerTestcase() && JUnitConfig.cleanOpenShift()) {
+            deleteProject(OpenShiftConfig.namespace(), false);
+        }
     }
 
     @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
         if (JUnitConfig.cleanOpenShift()) {
-            boolean deleted = openShift.deleteProject();
-            // For multi-module maven projects, other modules may attempt to crate project requests immediately after this modules deleteProject
-            if (deleted) {
-                BooleanSupplier bs = () -> openShift.getProject() == null;
-                new SimpleWaiter(bs, TimeUnit.MINUTES, 2, "Waiting for old project deletion").waitFor();
+            deleteProject(XTFConfig.get(OPENSHIFT_NAMESPACE), false);
+        }
+    }
+
+    private void deleteProject(String namespace, boolean waitForDeletion) {
+        OpenShift openShift = OpenShifts.master(namespace);
+        boolean deleted = openShift.deleteProject();
+        log.info("Start deleting namespace: " + openShift.getNamespace());
+        if (!deleted && waitForDeletion) {
+            BooleanSupplier bs = () -> openShift.getProject() == null;
+            new SimpleWaiter(bs, TimeUnit.MINUTES, 2, "Waiting for " + openShift.getNamespace() + " project deletion")
+                    .waitFor();
+        }
+    }
+
+    @Override
+    public FilterResult apply(TestDescriptor testDescriptor) {
+        if (testDescriptor instanceof MethodBasedTestDescriptor) {
+            boolean disabled = Arrays.stream(((MethodBasedTestDescriptor) testDescriptor).getTestClass().getAnnotations())
+                    .filter(annotation -> annotation instanceof Disabled).count() > 0;
+            if (!disabled) {
+                TestCaseContext.getRunningTestcase().putIfAbsent(
+                        ((MethodBasedTestDescriptor) testDescriptor).getTestClass().getName(),
+                        getNameSpaceForTestClass(testDescriptor));
+
             }
+        }
+        return FilterResult.included(testDescriptor.getDisplayName());
+    }
+
+    private String getNameSpaceForTestClass(TestDescriptor testDescriptor) {
+        if (OpenShiftConfig.useNamespacePerTestcase()) {
+            // some test case names can be really long resulting in long namespace names. This can cause issues
+            // with routes which have 64 chars limit for prefix of domain name. In case of route like:
+            // galleon-provisioning-xml-prio-mnovak-galleonprovisioningxmltest.apps.eapqe-024-dryf.eapqe.psi.redhat.com
+            // route prefix is: galleon-provisioning-xml-prio-mnovak-galleonprovisioningxmltest
+            // route suffix is: .apps.eapqe-024-dryf.eapqe.psi.redhat.com
+            if ((XTFConfig.get(OPENSHIFT_NAMESPACE) + "-"
+                    + testDescriptor.getParent().get().getDisplayName().toLowerCase())
+                            .length() > OpenShiftConfig.getNamespaceLengthLimitForUniqueNamespacePerTest()) {
+
+                return XTFConfig.get(OPENSHIFT_NAMESPACE) + "-"
+                        + StringUtils.truncate(DigestUtils.sha256Hex(testDescriptor.getParent().get().getDisplayName()
+                                .toLowerCase()),
+                                OpenShiftConfig.getNamespaceLengthLimitForUniqueNamespacePerTest()
+                                        - XTFConfig.get(OPENSHIFT_NAMESPACE).length());
+            } else {
+                return XTFConfig.get(OPENSHIFT_NAMESPACE) + "-"
+                        + testDescriptor.getParent().get().getDisplayName().toLowerCase(); // namespace must not have upper case letters
+            }
+        } else {
+            return OpenShiftConfig.namespace();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <version.assertj-core>3.17.2</version.assertj-core>
         <version.lombok>1.18.12</version.lombok>
         <version.gson>2.8.9</version.gson>
+        <version.guava>31.1-jre</version.guava>
 
         <!-- Plugin version properties -->
         <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
@@ -197,6 +198,13 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.logback-classic}</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${version.guava}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…ute every test case in its own namespace. Note this property has limitation that consuming test suite must not create static Openshift instances as those are created before name of test case and thus the namespace for the test is known.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
