### PR TITLE
Provide the full command

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
+++ b/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
@@ -155,12 +155,21 @@ public class DockerImageMetadata {
 
     /**
      * Returns default container command on Config/Cmd path
+     * If command consists of more parts, the space-separated string of all those parts is returned.
      *
      * @return default command
      */
     public String command() {
-        List<String> cmdList = (List<String>) getConfig().get(METADATA_CONFIG_CMD);
-        return cmdList.get(0);
+        return String.join(" ", commandList());
+    }
+
+    /**
+     * Returns default container command on Config/Cmd path - return all parts as a list
+     *
+     * @return default command list
+     */
+    public List<String> commandList() {
+        return (List<String>) getConfig().get(METADATA_CONFIG_CMD);
     }
 
     /**


### PR DESCRIPTION
The original implementation worked ok for one-part command list, eg:
```
"Cmd": [
    "/opt/eap/bin/openshift-launch.sh"
],
```

But we can't expect all commands to be given like this, we need to be
able to parse also eg:
```
"Cmd": [
    "sh",
    "-c",
    "${JBOSS_CONTAINER_WILDFLY_RUN_MODULE}/run"
],
```

This commits change the default behavior a bit (however, there is no change for those one-part commands) and adds new method to also be able to get command as list.

