### PR TITLE
Fix OpenShiftRecorderService in order to create a unique directory for parametrized tests

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
@@ -3,6 +3,7 @@ package cz.xtf.junit5.extensions;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
@@ -532,9 +533,10 @@ public class OpenShiftRecorderService {
     private String dirNameForTest(ExtensionContext context) {
         // if is test
         if (context.getTestMethod().isPresent()) {
-            return context.getTestClass().get().getName() + "." + context.getDisplayName();
+            return context.getTestClass().get().getName() + "." + context.getTestMethod().get().getName()
+                    + context.getDisplayName();
         } else {
-            return context.getTestClass().get().getName();
+            return context.getTestClass().get().getName() + "-" + ThreadLocalRandom.current().nextInt(Short.MAX_VALUE);
         }
     }
 }


### PR DESCRIPTION
Adds the test method name to the generated directory name for parametrized tests, so that files can be downloaded without overriding existing ones.

FYI @mnovak1 (CC @simkam) - I am keeping this as a draft while I collect some runs to check the changes. Feel free to let me know what you think.
 
Fix #501 

Local execution with changes shows that now the test name is now used to compute the output directory name, so it will be unique for parametrized tests too:

```
ls -l junit5/
total 32
drwxrwxr-x. 2 fburzigo fburzigo 1024 Aug 29 13:41 cz.xtf.junit5.extensions.OpenShiftRecorderTest.failingParameterTest[2] 1
drwxrwxr-x. 2 fburzigo fburzigo 1024 Aug 29 13:41 cz.xtf.junit5.extensions.OpenShiftRecorderTest.failingParameterTest[3] 2
drwxrwxr-x. 2 fburzigo fburzigo 1024 Aug 29 13:42 cz.xtf.junit5.extensions.OpenShiftRecorderTest.yetAnotherFailingParameterTest[2] 1
drwxrwxr-x. 2 fburzigo fburzigo 1024 Aug 29 13:42 cz.xtf.junit5.extensions.OpenShiftRecorderTest.yetAnotherFailingParameterTest[3] 2
...
```

The alternative conditional branch in `dirNameForTest()` has been fixed too, in order to add a random unique id to the directory name even in the case `context.getTestMethod()` is not defined.  

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
