### PR TITLE
Skip builds also for disabled test classes

### DIFF
--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-jupiter</artifactId>
             <scope>test</scope>

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -169,11 +170,12 @@ public class ManagedBuildPrebuilder implements TestExecutionListener {
     }
 
     static boolean shouldSkipBuildsForClass(Class<?> klass) {
+        boolean classDisabled = Arrays.stream(klass.getAnnotationsByType(Disabled.class)).findAny().isPresent();
         boolean classSkippedForStream = Arrays.stream(klass.getAnnotationsByType(SkipFor.class))
                 .anyMatch(a -> SkipForCondition.resolve(a).isDisabled());
         boolean classSkippedForTestedVersion = Arrays.stream(klass.getAnnotationsByType(SinceVersion.class))
                 .anyMatch(a -> SinceVersionCondition.resolve(a).isDisabled());
 
-        return classSkippedForStream || classSkippedForTestedVersion;
+        return classDisabled || classSkippedForStream || classSkippedForTestedVersion;
     }
 }

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
@@ -137,16 +137,12 @@ public class ManagedBuildPrebuilder implements TestExecutionListener {
             TestSource testSource = identifier.getSource().get();
             if (testSource instanceof ClassSource) {
                 ClassSource classSource = (ClassSource) testSource;
-                Class klass = classSource.getJavaClass();
+                Class<?> klass = classSource.getJavaClass();
 
                 log.debug("Processing {}", klass);
 
                 // We don't want to prepare build when whole test case is skipped
-                boolean classSkippedForStream = Arrays.stream(klass.getAnnotationsByType(SkipFor.class))
-                        .anyMatch(a -> SkipForCondition.resolve((SkipFor) a).isDisabled());
-                boolean classSkippedForTestedVersion = Arrays.stream(klass.getAnnotationsByType(SinceVersion.class))
-                        .anyMatch(a -> SinceVersionCondition.resolve((SinceVersion) a).isDisabled());
-                if (classSkippedForStream || classSkippedForTestedVersion) {
+                if (shouldSkipBuildsForClass(klass)) {
                     return;
                 }
 
@@ -170,5 +166,14 @@ public class ManagedBuildPrebuilder implements TestExecutionListener {
                         });
             }
         }
+    }
+
+    static boolean shouldSkipBuildsForClass(Class<?> klass) {
+        boolean classSkippedForStream = Arrays.stream(klass.getAnnotationsByType(SkipFor.class))
+                .anyMatch(a -> SkipForCondition.resolve(a).isDisabled());
+        boolean classSkippedForTestedVersion = Arrays.stream(klass.getAnnotationsByType(SinceVersion.class))
+                .anyMatch(a -> SinceVersionCondition.resolve(a).isDisabled());
+
+        return classSkippedForStream || classSkippedForTestedVersion;
     }
 }

--- a/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
+++ b/junit5/src/test/java/cz/xtf/junit5/extensions/SkipForConditionTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import cz.xtf.core.config.XTFConfig;
 import cz.xtf.junit5.annotations.SkipFor;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -23,8 +24,8 @@ class SkipForConditionTest {
     @BeforeEach
     void before() {
         systemProperties.set("xtf.eap.subid", "74-openjdk11");
-        systemProperties.set("xtf.eap.74-openjdk11.image",
-                "quay.io/wildfly/wildfly-centos7:latest");
+        systemProperties.set("xtf.eap.74-openjdk11.image", "quay.io/wildfly/wildfly-centos7:latest");
+        XTFConfig.loadConfig();
     }
 
     @SkipFor(image = "eap", name = ".*eap-74.*", reason = "This test is skipped based on the image name.")

--- a/junit5/src/test/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilderTest.java
+++ b/junit5/src/test/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilderTest.java
@@ -1,0 +1,105 @@
+package cz.xtf.junit5.listeners;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import cz.xtf.core.bm.BinaryBuild;
+import cz.xtf.core.config.XTFConfig;
+import cz.xtf.junit5.annotations.SinceVersion;
+import cz.xtf.junit5.annotations.SkipFor;
+import cz.xtf.junit5.annotations.UsesBuild;
+import cz.xtf.junit5.interfaces.BuildDefinition;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+@ExtendWith(SystemStubsExtension.class)
+class ManagedBuildPrebuilderTest {
+
+    @SystemStub
+    private SystemProperties systemProperties;
+
+    @BeforeEach
+    public void before() {
+        systemProperties.set("xtf.eap.subid", "test");
+        // tests are relying on this specific version, change with caution when needed
+        systemProperties.set("xtf.eap.test.image", "quay.io/wildfly/wildfly-s2i-jdk11:26.0");
+        XTFConfig.loadConfig();
+    }
+
+    @Test
+    public void buildFromClassWithoutSkipConditionsIsNotSkipped() {
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassTest.class)).isFalse();
+    }
+
+    @Test
+    public void buildFromSkippedClassIsSkipped() {
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassSkippedForImageTest.class)).isTrue();
+    }
+
+    @Test
+    public void buildFromClassSkippedDueToLowVersionIsSkipped() {
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassSkippedForLowerVersionTest.class))
+                .isTrue();
+    }
+
+    @Test
+    public void buildFromClassWithHighEnoughVersionIsNotSkipped() {
+        System.setProperty("xtf.eap.test.image", "quay.io/wildfly/wildfly-s2i-jdk11:27.0");
+        XTFConfig.loadConfig();
+
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassSkippedForLowerVersionTest.class))
+                .isFalse();
+    }
+
+    @Test
+    public void buildFromClassMatchingAllSkipConditionsIsSkipped() {
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassSkippedByAllConditionsTest.class))
+                .isTrue();
+    }
+
+    // --- test resources ---
+    @UsesTestBuild(TestBuilds.testBuild)
+    static class TestClassTest {
+    }
+
+    @SkipFor(image = "eap", name = "wildfly-s2i-jdk11", reason = "This test is skipped based on the image name.")
+    @UsesTestBuild(TestBuilds.testBuild)
+    static class TestClassSkippedForImageTest {
+    }
+
+    @SinceVersion(image = "eap", name = "wildfly-s2i-jdk11", since = "27.0", jira = "JIRA-1234")
+    @UsesTestBuild(TestBuilds.testBuild)
+    static class TestClassSkippedForLowerVersionTest {
+    }
+
+    @SkipFor(image = "eap", name = "wildfly-s2i-jdk11", reason = "This test is skipped based on the image name.")
+    @SinceVersion(image = "eap", name = "wildfly-s2i-jdk11", since = "27.0", jira = "JIRA-1234")
+    @UsesTestBuild(TestBuilds.testBuild)
+    static class TestClassSkippedByAllConditionsTest {
+    }
+
+    enum TestBuilds implements BuildDefinition<BinaryBuild> {
+        testBuild;
+
+        @Override
+        public BinaryBuild getManagedBuild() {
+            return null;
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @UsesBuild
+    @interface UsesTestBuild {
+        TestBuilds value();
+    }
+
+}

--- a/junit5/src/test/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilderTest.java
+++ b/junit5/src/test/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilderTest.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -60,6 +61,11 @@ class ManagedBuildPrebuilderTest {
     }
 
     @Test
+    public void buildFromDisabledClassIsSkipped() {
+        Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassDisabledTest.class)).isTrue();
+    }
+
+    @Test
     public void buildFromClassMatchingAllSkipConditionsIsSkipped() {
         Assertions.assertThat(ManagedBuildPrebuilder.shouldSkipBuildsForClass(TestClassSkippedByAllConditionsTest.class))
                 .isTrue();
@@ -80,8 +86,14 @@ class ManagedBuildPrebuilderTest {
     static class TestClassSkippedForLowerVersionTest {
     }
 
+    @Disabled("Some reason given")
+    @UsesTestBuild(TestBuilds.testBuild)
+    static class TestClassDisabledTest {
+    }
+
     @SkipFor(image = "eap", name = "wildfly-s2i-jdk11", reason = "This test is skipped based on the image name.")
     @SinceVersion(image = "eap", name = "wildfly-s2i-jdk11", since = "27.0", jira = "JIRA-1234")
+    @Disabled("Some reason given")
     @UsesTestBuild(TestBuilds.testBuild)
     static class TestClassSkippedByAllConditionsTest {
     }


### PR DESCRIPTION
Before this PR, when class is annotated with `@SkipFor` or `@SinceVersion` and these annotations result in test class being skipped, we also skip pre-building of configured builds for that class (introduced in https://github.com/xtf-cz/xtf/pull/277).

This PR extends the check to also skip the build when test class is annotated with JUnit `@Disabled` annotation which further optimizes the execution.

Also some tests were added to verify the previous and enhanced behaviour.
