### PR TITLE
[#507] support mountTrustedCA in BuildConfigBuilder

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/BuildConfigBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/BuildConfigBuilder.java
@@ -41,6 +41,7 @@ public class BuildConfigBuilder extends AbstractBuilder<BuildConfig, BuildConfig
     private String secretDestinationDir;
     private boolean binaryBuild;
     private boolean configChangeTrigger;
+    private boolean mountTrustedCA;
 
     private BuildStrategy strategy;
     private ImageSource imageSource;
@@ -114,6 +115,11 @@ public class BuildConfigBuilder extends AbstractBuilder<BuildConfig, BuildConfig
 
     public BuildConfigBuilder withBinaryBuild() {
         this.binaryBuild = true;
+        return this;
+    }
+
+    public BuildConfigBuilder withMountTrustedCA() {
+        this.mountTrustedCA = true;
         return this;
     }
 
@@ -218,6 +224,8 @@ public class BuildConfigBuilder extends AbstractBuilder<BuildConfig, BuildConfig
         }
 
         spec
+                // mountTrustedCA
+                .withMountTrustedCA(mountTrustedCA)
                 // triggers
                 .withTriggers(triggers)
                 // source


### PR DESCRIPTION
fixes https://github.com/xtf-cz/xtf/issues/507

On OCP3 the property is ignored.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
