### PR TITLE
Fix namespace deletion

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ProjectCreator.java
@@ -48,7 +48,7 @@ public class ProjectCreator
     @Override
     public void afterAll(ExtensionContext context) {
         if (JUnitConfig.cleanOpenShift()) {
-            NamespaceManager.deleteProject(false);
+            NamespaceManager.deleteProjectIfUsedNamespacePerTestCase(false);
         }
     }
 


### PR DESCRIPTION
Namespace deletion between test cases causes intermittent issues. If namespace is created before it's actually deleted then creation of namespace looks like as namespace already exists and it's deleted a few seconds later causing unexpected issues. 

Unfortunately it looks like that kubernetes-client API does not provide reliable way to detect deleted namespace. Thus moving back to safe point and if `xtf.openshift.namespace.per.testcase=false` which is by default do not delete namespace. Only if `xtf.openshift.namespace.per.testcase=true` then delete namespace with nowait.

Also make deletion of namespace using `NamespaceManager.deleteProject(...)` more robust.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented


