### PR TITLE
Helm post 3.10 changes

### DIFF
--- a/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
@@ -51,6 +51,7 @@ public class HelmBinary {
         environmentVariables.put("HELM_KUBEASUSER", kubeUsername);
         environmentVariables.put("HELM_KUBETOKEN", kubeToken);
         environmentVariables.put("HELM_NAMESPACE", namespace);
+        environmentVariables.put("HELM_KUBEINSECURE_SKIP_TLS_VERIFY", "true");
         return CLIUtils.executeCommand(environmentVariables, ArrayUtils.addAll(new String[] { path }, args));
     }
 

--- a/core/src/main/java/cz/xtf/core/openshift/CLIUtils.java
+++ b/core/src/main/java/cz/xtf/core/openshift/CLIUtils.java
@@ -3,7 +3,6 @@ package cz.xtf.core.openshift;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -48,11 +47,11 @@ public class CLIUtils {
             if (result == 0) {
                 return out.get();
             } else {
-                log.error("Failed while executing (code {}): {}", result, Arrays.toString(args));
+                log.error("Failed while executing (code {}): {}", result, String.join(" ", args));
                 log.error(err.get());
             }
         } catch (IOException | InterruptedException | ExecutionException e) {
-            log.error("Failed while executing: " + Arrays.toString(args), e);
+            log.error("Failed while executing: " + String.join(" ", args), e);
         }
 
         return null;


### PR DESCRIPTION
Helm v 3.10 adds support for `HELM_KUBEINSECURE_SKIP_TLS_VERIFY` environment variable (or `--kube-insecure-skip-tls-verify`) flag that doesn't require further kubecontext to be used in order for successful authentication. Such feature will be beneficial from testing POV. This PR addresses it.
