### PR TITLE
Use correct BUILD_FILTER_BUILDS filter for build namespace

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
@@ -211,7 +211,7 @@ public class OpenShiftRecorderService {
         savePodLogs(context, getFilter(context, POD_FILTER_MASTER),
                 !isMasterAndBuildNamespaceSame() ? getFilter(context, POD_FILTER_BUILDS) : null);
         saveBuildLogs(context, getFilter(context, BUILD_FILTER_MASTER),
-                !isMasterAndBuildNamespaceSame() ? getFilter(context, BUILD_FILTER_MASTER) : null);
+                !isMasterAndBuildNamespaceSame() ? getFilter(context, BUILD_FILTER_BUILDS) : null);
         saveEvents(context, getFilter(context, EVENT_FILTER_MASTER),
                 !isMasterAndBuildNamespaceSame() ? getFilter(context, EVENT_FILTER_BUILDS) : null);
     }


### PR DESCRIPTION
I noticed this mismatch where all other save* calls differentiate filters for master and build namespace and only this one doesn't which is a bug introduced during refactoring and introducing this new `saveBuildLogs` method.