### PR TITLE
Configure VolumeMounts with subPath in ContainerBuilder

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
@@ -128,6 +128,16 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
         return this;
     }
 
+    public ContainerBuilder addVolumeMount(String name, String mountPath, boolean readOnly, String subPath) {
+        this.volumeMounts.add(new VolumeMount(name, mountPath, readOnly, subPath));
+        return this;
+    }
+
+    public ContainerBuilder addVolumeMount(VolumeMount volumeMount) {
+        this.volumeMounts.add(volumeMount);
+        return this;
+    }
+
     public LivenessProbe addLivenessProbe() {
         this.livenessProbe = new LivenessProbe();
         return (LivenessProbe) this.livenessProbe;
@@ -205,6 +215,7 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
                 .withName(item.getName())
                 .withMountPath(item.getMountPath())
                 .withReadOnly(item.isReadOnly())
+                .withSubPath(item.getSubPath())
                 .build()).collect(Collectors.toList()));
 
         final List<ComputingResource> requests = computingResources.values().stream().filter(x -> x.getRequests() != null)
@@ -269,30 +280,6 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
 
     public void addPreStopHandler(Handler handler) {
         preStopHandler = handler;
-    }
-
-    private static class VolumeMount {
-        private String mountPath;
-        private String name;
-        private boolean readOnly;
-
-        public VolumeMount(String name, String mountPath, boolean readOnly) {
-            this.mountPath = mountPath;
-            this.name = name;
-            this.readOnly = readOnly;
-        }
-
-        public String getMountPath() {
-            return mountPath;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public boolean isReadOnly() {
-            return readOnly;
-        }
     }
 
     private static class ContainerPort {

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/VolumeMount.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/VolumeMount.java
@@ -1,0 +1,37 @@
+package cz.xtf.builder.builders.pod;
+
+public class VolumeMount {
+    private String mountPath;
+    private String name;
+    private boolean readOnly;
+    private String subPath;
+
+    public VolumeMount(String name, String mountPath, boolean readOnly) {
+        this.mountPath = mountPath;
+        this.name = name;
+        this.readOnly = readOnly;
+    }
+
+    public VolumeMount(String name, String mountPath, boolean readOnly, String subPath) {
+        this.mountPath = mountPath;
+        this.name = name;
+        this.readOnly = readOnly;
+        this.subPath = subPath;
+    }
+
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public String getSubPath() {
+        return subPath;
+    }
+}


### PR DESCRIPTION
This MR introduces the option to configure volumeMounts with subPath through cz.xtf.builder.builders.pod.ContainerBuilder

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
