### PR TITLE
add startup probe

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/deployment/StartupProbe.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/deployment/StartupProbe.java
@@ -1,0 +1,44 @@
+package cz.xtf.builder.builders.deployment;
+
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
+
+public class StartupProbe extends AbstractProbe {
+
+    private int failureThreshold = -1;
+    private int periodSeconds = -1;
+
+    private int initialDelay = -1;
+
+    public StartupProbe setFailureThreshold(int failureThreshold) {
+        this.failureThreshold = failureThreshold;
+        return this;
+    }
+
+    public StartupProbe setPeriodSeconds(int periodSeconds) {
+        this.periodSeconds = periodSeconds;
+        return this;
+    }
+
+    public StartupProbe setInitialDelay(int initialDelay) {
+        this.initialDelay = initialDelay;
+        return this;
+    }
+
+    public StartupProbe createHttpProbe(String path, String port) {
+        return (StartupProbe) super.createHttpProbe(path, port);
+    }
+
+    @Override
+    protected void build(ProbeBuilder builder) {
+        if (failureThreshold > 0) {
+            builder.withFailureThreshold(failureThreshold);
+        }
+        if (periodSeconds > 0) {
+            builder.withPeriodSeconds(periodSeconds);
+        }
+        if (initialDelay > 0) {
+            builder.withInitialDelaySeconds(initialDelay);
+        }
+
+    }
+}

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
@@ -20,6 +20,7 @@ import cz.xtf.builder.builders.deployment.AbstractProbe;
 import cz.xtf.builder.builders.deployment.Handler;
 import cz.xtf.builder.builders.deployment.LivenessProbe;
 import cz.xtf.builder.builders.deployment.ReadinessProbe;
+import cz.xtf.builder.builders.deployment.StartupProbe;
 import cz.xtf.builder.builders.limits.CPUResource;
 import cz.xtf.builder.builders.limits.ComputingResource;
 import cz.xtf.builder.builders.limits.MemoryResource;
@@ -49,6 +50,7 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
     private boolean privileged = false;
     private AbstractProbe livenessProbe;
     private AbstractProbe readinessProbe;
+    private StartupProbe startupProbe;
     private Handler preStopHandler;
     private String[] command;
 
@@ -148,6 +150,11 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
         return (ReadinessProbe) this.readinessProbe;
     }
 
+    public StartupProbe addStartupProbe() {
+        this.startupProbe = new StartupProbe();
+        return (StartupProbe) this.startupProbe;
+    }
+
     public ContainerBuilder addReadinessProbe(AbstractProbe readinessProbe) {
         this.readinessProbe = readinessProbe;
         return this;
@@ -209,6 +216,10 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
 
         if (readinessProbe != null) {
             builder.withReadinessProbe(readinessProbe.build());
+        }
+
+        if (startupProbe != null) {
+            builder.withStartupProbe(startupProbe.build());
         }
 
         builder.withVolumeMounts(volumeMounts.stream().map(item -> new VolumeMountBuilder()

--- a/builder/src/main/java/cz/xtf/builder/db/AbstractDatabase.java
+++ b/builder/src/main/java/cz/xtf/builder/db/AbstractDatabase.java
@@ -24,6 +24,7 @@ public abstract class AbstractDatabase extends DefaultStatefulAuxiliary {
 
     protected boolean withLivenessProbe;
     protected boolean withReadinessProbe;
+    protected boolean withStartupProbe;
 
     public AbstractDatabase(String symbolicName, String dataDir) {
         this("testuser", "testpwd", "testdb", symbolicName, dataDir);
@@ -42,6 +43,16 @@ public abstract class AbstractDatabase extends DefaultStatefulAuxiliary {
         this.configureEnvironment = configureEnvironment;
     }
 
+    public AbstractDatabase(String symbolicName, String dataDir, boolean withLivenessProbe, boolean withReadinessProbe,
+            boolean withStartupProbe,
+            boolean configureEnvironment) {
+        this(symbolicName, dataDir);
+        this.withLivenessProbe = withLivenessProbe;
+        this.withReadinessProbe = withReadinessProbe;
+        this.withStartupProbe = withStartupProbe;
+        this.configureEnvironment = configureEnvironment;
+    }
+
     public AbstractDatabase(String symbolicName, String dataDir, PersistentVolumeClaim pvc) {
         this("testuser", "testpwd", "testdb", symbolicName, dataDir, pvc);
     }
@@ -52,6 +63,15 @@ public abstract class AbstractDatabase extends DefaultStatefulAuxiliary {
 
         this.withLivenessProbe = withLivenessProbe;
         this.withReadinessProbe = withReadinessProbe;
+    }
+
+    public AbstractDatabase(String symbolicName, String dataDir, PersistentVolumeClaim pvc, boolean withLivenessProbe,
+            boolean withReadinessProbe, boolean withStartupProbe) {
+        this("testuser", "testpwd", "testdb", symbolicName, dataDir, pvc);
+
+        this.withLivenessProbe = withLivenessProbe;
+        this.withReadinessProbe = withReadinessProbe;
+        this.withStartupProbe = withStartupProbe;
     }
 
     public AbstractDatabase(String username, String password, String dbName, String symbolicName, String dataDir) {
@@ -78,6 +98,15 @@ public abstract class AbstractDatabase extends DefaultStatefulAuxiliary {
             boolean withLivenessProbe, boolean withReadinessProbe, boolean configureEnvironment) {
         this(username, password, dbName, symbolicName, dataDir, withLivenessProbe, withReadinessProbe);
         this.configureEnvironment = configureEnvironment;
+    }
+
+    public AbstractDatabase(String username, String password, String dbName, String symbolicName, String dataDir,
+            boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe, boolean configureEnvironment) {
+        this(username, password, dbName, symbolicName, dataDir);
+        this.configureEnvironment = configureEnvironment;
+        this.withLivenessProbe = withLivenessProbe;
+        this.withReadinessProbe = withReadinessProbe;
+        this.withStartupProbe = withStartupProbe;
     }
 
     public abstract String getImageName();
@@ -216,6 +245,7 @@ public abstract class AbstractDatabase extends DefaultStatefulAuxiliary {
     public AbstractDatabase withProbes() {
         withLivenessProbe = true;
         withReadinessProbe = true;
+        withStartupProbe = true;
         return this;
     }
 

--- a/builder/src/main/java/cz/xtf/builder/db/AbstractSQLDatabase.java
+++ b/builder/src/main/java/cz/xtf/builder/db/AbstractSQLDatabase.java
@@ -21,6 +21,12 @@ public abstract class AbstractSQLDatabase extends AbstractDatabase implements SQ
         super(symbolicName, dataDir, withLivenessProbe, withReadinessProbe, configureEnvironment);
     }
 
+    public AbstractSQLDatabase(String symbolicName, String dataDir, boolean withLivenessProbe, boolean withReadinessProbe,
+            boolean withStartupProbe,
+            boolean configureEnvironment) {
+        super(symbolicName, dataDir, withLivenessProbe, withReadinessProbe, withStartupProbe, configureEnvironment);
+    }
+
     public AbstractSQLDatabase(String username, String password, String dbName, String symbolicName, String dataDir,
             boolean withLivenessProbe, boolean withReadinessProbe) {
         super(username, password, dbName, symbolicName, dataDir, withLivenessProbe, withReadinessProbe);
@@ -31,9 +37,20 @@ public abstract class AbstractSQLDatabase extends AbstractDatabase implements SQ
         super(username, password, dbName, symbolicName, dataDir, withLivenessProbe, withReadinessProbe, configureEnvironment);
     }
 
+    public AbstractSQLDatabase(String username, String password, String dbName, String symbolicName, String dataDir,
+            boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe, boolean configureEnvironment) {
+        super(username, password, dbName, symbolicName, dataDir, withLivenessProbe, withReadinessProbe, withStartupProbe,
+                configureEnvironment);
+    }
+
     public AbstractSQLDatabase(String symbolicName, String dataDir, PersistentVolumeClaim pvc, boolean withLivenessProbe,
             boolean withReadinessProbe) {
         super(symbolicName, dataDir, pvc, withLivenessProbe, withReadinessProbe);
+    }
+
+    public AbstractSQLDatabase(String symbolicName, String dataDir, PersistentVolumeClaim pvc, boolean withLivenessProbe,
+            boolean withReadinessProbe, boolean withStartupProbe) {
+        super(symbolicName, dataDir, pvc, withLivenessProbe, withReadinessProbe, withStartupProbe);
     }
 
     public AbstractSQLDatabase(String symbolicName, String dataDir, PersistentVolumeClaim pvc) {
@@ -95,6 +112,13 @@ public abstract class AbstractSQLDatabase extends AbstractDatabase implements SQ
                     .setInitialDelaySeconds(settings.getReadinessInitialDelaySeconds())
                     .createExecProbe("/bin/sh", "-i", "-c",
                             settings.getReadinessProbeCommand());
+        }
+        if (withStartupProbe) {
+            containerBuilder.addStartupProbe()
+                    .setFailureThreshold(settings.getStartupFailureThreshold())
+                    .setPeriodSeconds(settings.getStartupPeriodSeconds())
+                    .createExecProbe("/bin/sh", "-i", "-c",
+                            settings.getStartupProbeCommand());
         }
     }
 

--- a/builder/src/main/java/cz/xtf/builder/db/MySQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/MySQL.java
@@ -13,12 +13,20 @@ public class MySQL extends AbstractSQLDatabase {
         super("MYSQL", "/var/lib/mysql/data", withLivenessProbe, withReadinessProbe);
     }
 
+    public MySQL(boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
+        super("MYSQL", "/var/lib/mysql/data", withLivenessProbe, withReadinessProbe, withStartupProbe, true);
+    }
+
     public MySQL(PersistentVolumeClaim pvc) {
         super("MYSQL", "/var/lib/mysql/data", pvc);
     }
 
     public MySQL(PersistentVolumeClaim pvc, boolean withLivenessProbe, boolean withReadinessProbe) {
         super("MYSQL", "/var/lib/mysql/data", pvc, withLivenessProbe, withReadinessProbe);
+    }
+
+    public MySQL(PersistentVolumeClaim pvc, boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
+        super("MYSQL", "/var/lib/mysql/data", pvc, withLivenessProbe, withReadinessProbe, withStartupProbe);
     }
 
     public MySQL(String username, String password, String dbName) {
@@ -40,7 +48,11 @@ public class MySQL extends AbstractSQLDatabase {
         return new ProbeSettings(30,
                 String.valueOf(getPort()),
                 5,
-                "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'");
+                "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'",
+                5,
+                "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'",
+                10,
+                10);
     }
 
     @Override

--- a/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/PostgreSQL.java
@@ -15,6 +15,10 @@ public class PostgreSQL extends AbstractSQLDatabase {
         super("POSTGRESQL", "/var/lib/pgsql/data", withLivenessProbe, withReadinessProbe);
     }
 
+    public PostgreSQL(boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
+        super("POSTGRESQL", "/var/lib/pgsql/data", withLivenessProbe, withReadinessProbe, withStartupProbe, true);
+    }
+
     public PostgreSQL(PersistentVolumeClaim pvc) {
         super("POSTGRESQL", "/var/lib/pgsql/data", pvc);
     }
@@ -23,12 +27,21 @@ public class PostgreSQL extends AbstractSQLDatabase {
         super("POSTGRESQL", "/var/lib/pgsql/data", pvc, withLivenessProbe, withReadinessProbe);
     }
 
+    public PostgreSQL(PersistentVolumeClaim pvc, boolean withLivenessProbe, boolean withReadinessProbe,
+            boolean withStartupProbe) {
+        super("POSTGRESQL", "/var/lib/pgsql/data", pvc, withLivenessProbe, withReadinessProbe, withStartupProbe);
+    }
+
     public PostgreSQL(String username, String password, String dbName) {
         super(username, password, dbName, "POSTGRESQL", "/var/lib/pgsql/data");
     }
 
     public PostgreSQL(String symbolicName, boolean withLivenessProbe, boolean withReadinessProbe) {
         super(symbolicName, "/var/lib/pgsql/data", withLivenessProbe, withReadinessProbe);
+    }
+
+    public PostgreSQL(String symbolicName, boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
+        super(symbolicName, "/var/lib/pgsql/data", withLivenessProbe, withReadinessProbe, withStartupProbe, true);
     }
 
     @Override
@@ -45,7 +58,11 @@ public class PostgreSQL extends AbstractSQLDatabase {
         return new ProbeSettings(300,
                 String.valueOf(getPort()),
                 5,
-                "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'");
+                "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'",
+                5,
+                "psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'",
+                10,
+                10);
     }
 
     @Override

--- a/builder/src/main/java/cz/xtf/builder/db/ProbeSettings.java
+++ b/builder/src/main/java/cz/xtf/builder/db/ProbeSettings.java
@@ -14,4 +14,8 @@ public class ProbeSettings {
     private String livenessTcpProbe;
     private int readinessInitialDelaySeconds;
     private String readinessProbeCommand;
+    private int startupInitialDelaySeconds;
+    private String startupProbeCommand;
+    private int startupFailureThreshold;
+    private int startupPeriodSeconds;
 }


### PR DESCRIPTION
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented

Adding startup probe functionality.

This code works as is, but if the startup probe fails tests still wait for a timeout. I propose also modifying waiter behavior to fail immediately if the startup probe is present and fails WDYT @mnovak1 ?

Resolves #520.