### PR TITLE
Record files from one Before* method failure to same directory

### DIFF
--- a/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/OpenShiftRecorderService.java
@@ -89,6 +89,8 @@ public class OpenShiftRecorderService {
     private static final String IS_FILTER_BUILDS = "IS_FILTER_BUILDS";
     private static final String EVENT_FILTER_BUILDS = "EVENT_FILTER_BUILDS";
 
+    private int uniqueExecutionIdentifier;
+
     /**
      * Initialize filters by collecting information OCP resources which are relevant for the current test execution
      * context (e.g.: called by a {@link org.junit.jupiter.api.extension.BeforeAllCallback#beforeAll(ExtensionContext)}
@@ -194,6 +196,8 @@ public class OpenShiftRecorderService {
      * Retrieves resources identified by filters
      */
     public void recordState(ExtensionContext context) throws IOException {
+        uniqueExecutionIdentifier = ThreadLocalRandom.current().nextInt(Short.MAX_VALUE);
+
         savePods(context, getFilter(context, POD_FILTER_MASTER),
                 !isMasterAndBuildNamespaceSame() ? getFilter(context, POD_FILTER_BUILDS) : null);
         saveDCs(context, getFilter(context, DC_FILTER_MASTER));
@@ -536,7 +540,7 @@ public class OpenShiftRecorderService {
             return context.getTestClass().get().getName() + "." + context.getTestMethod().get().getName()
                     + context.getDisplayName();
         } else {
-            return context.getTestClass().get().getName() + "-" + ThreadLocalRandom.current().nextInt(Short.MAX_VALUE);
+            return context.getTestClass().get().getName() + "-" + uniqueExecutionIdentifier;
         }
     }
 }


### PR DESCRIPTION
Change OpenShiftRecorder to store logs from single Before* method failure into same directory. Currently it generates random integer, for directory name, every time writing a file. Resulting in storing every *.log file into separate directory.

This MR generates unique identifier every time a openshift state is stored and uses it as identifier for all files.

Changes behaviour from https://github.com/xtf-cz/xtf/pull/504

Please make sure your PR meets the following requirements:
- [ ] Pull Request contains a description of the changes
- [ ] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented
