### PR TITLE
Configure Apache compress - use POSIX due to big group ID number of linux user

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BinaryBuildFromSources.java
+++ b/core/src/main/java/cz/xtf/core/bm/BinaryBuildFromSources.java
@@ -104,6 +104,7 @@ abstract public class BinaryBuildFromSources extends BinaryBuild {
         try (TarArchiveOutputStream o = (TarArchiveOutputStream) new ArchiveStreamFactory()
                 .createArchiveOutputStream(ArchiveStreamFactory.TAR, os)) {
             o.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            o.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             for (File f : filesToArchive) {
                 String tarPath = getPath().relativize(f.toPath()).toString();
                 log.trace("adding file to tar: {}", tarPath);


### PR DESCRIPTION
Due to big group ID number of the user the Apache compress throw exception when the user have big number as his group ID.  The big numbers can allowed by POSIX.
