### PR TITLE
upgrade impsort-maven-plugin

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -13,16 +13,24 @@ jobs:
   test:
     name: Build and CheckStyle
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
           java-package: jdk
           architecture: x64
+          cache: 'maven'
       - name: Check well-formatted code
+        # impsort-maven-plugin requires JDK 11 and profile is active only on JDK11
+        if: ${{ matrix.java == 11 }}
         run: mvn -B formatter:validate impsort:check
       - name: Maven Package
         run: mvn install -B -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/pom.xml
+++ b/pom.xml
@@ -299,24 +299,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>net.revelc.code</groupId>
-                <artifactId>impsort-maven-plugin</artifactId>
-                <version>1.3.2</version>
-                <configuration>
-                    <groups>java.,javax.,org.,com.</groups>
-                    <staticGroups>*</staticGroups>
-                    <removeUnused>true</removeUnused>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>sort-imports</id>
-                        <goals>
-                            <goal>sort</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -362,6 +344,35 @@
                                 <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- impsort-maven-plugin requires JDK 11 -->
+            <id>run-impsort</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <version>1.8.0</version>
+                        <configuration>
+                            <groups>java.,javax.,org.,com.</groups>
+                            <staticGroups>*</staticGroups>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
 impsort-maven-plugin requires JDK 11, old version that support JDK8 doesn't work with the latest maven

https://github.com/revelc/impsort-maven-plugin/issues/64

