### PR TITLE
Fixing BuildManager in order not to create a system:image-puller role for the authenticated users when the master and build namespaces are set to the same value

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BuildManager.java
+++ b/core/src/main/java/cz/xtf/core/bm/BuildManager.java
@@ -49,7 +49,9 @@ public class BuildManager {
             openShift.setupPullSecret(OpenShiftConfig.pullSecret());
         }
 
-        openShift.addRoleToGroup("system:image-puller", "ClusterRole", "system:authenticated");
+        if (!BuildManagerConfig.namespace().equals(OpenShiftConfig.namespace())) {
+            openShift.addRoleToGroup("system:image-puller", "ClusterRole", "system:authenticated");
+        }
     }
 
     public ManagedBuildReference deploy(ManagedBuild managedBuild) {


### PR DESCRIPTION
Fix #536 

Tests passed locally.

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
