### PR TITLE
Adding a validation method to XTFConfig to check that build and master namespace don't collide

### DIFF
--- a/core/src/main/java/cz/xtf/core/config/XTFConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/XTFConfig.java
@@ -35,6 +35,7 @@ public final class XTFConfig {
     // Pre-loading
     static {
         loadConfig();
+        validateConfig();
     }
 
     public static void loadConfig() {
@@ -49,6 +50,13 @@ public final class XTFConfig {
 
         // Set new values based on old properties if new are not set
         BackwardCompatibility.updateProperties();
+    }
+
+    public static void validateConfig() {
+        if (BuildManagerConfig.namespace().equals(OpenShiftConfig.namespace())) {
+            throw new IllegalStateException(
+                    "The xtf.openshift.namespace and xtf.bm.namespace properties cannot be set to the same value.");
+        }
     }
 
     public static String get(String property) {


### PR DESCRIPTION
Adding a validation method to XTFConfig, which is called by a static block in order to check that build and master namespace don't collide since this might cause leftover resources to be found by OpenShift::clean()

Fix #536 - alternative to #537 

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
