### PR TITLE
Removed HELM_KUBEASUSER from Helm binary + changed rvelc plugin versions

### DIFF
--- a/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/OpenShiftConfig.java
@@ -87,7 +87,7 @@ public final class OpenShiftConfig {
 
     /**
      * Used only if xtf.openshift.namespace.per.testcase=true
-     * 
+     *
      * @return limit on namespace if it's set by -Dxtf.openshift.namespace.per.testcase.length.limit property
      */
     public static int getNamespaceLengthLimitForUniqueNamespacePerTest() {

--- a/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
@@ -18,13 +18,11 @@ public class HelmBinary {
 
     private final String path;
     private final String helmConfigPath;
-    private final String kubeUsername;
     private final String kubeToken;
     private final String namespace;
 
-    public HelmBinary(String path, String kubeUsername, String kubeToken, String namespace) {
+    public HelmBinary(String path, String kubeToken, String namespace) {
         this.path = path;
-        this.kubeUsername = kubeUsername;
         this.kubeToken = kubeToken;
         Path helmConfigFile = Paths.get(path).getParent().resolve(".config");
         try {
@@ -39,7 +37,6 @@ public class HelmBinary {
     public HelmBinary(String path, String helmConfigPath, String kubeUsername, String kubeToken, String namespace) {
         this.path = path;
         this.helmConfigPath = helmConfigPath;
-        this.kubeUsername = kubeUsername;
         this.kubeToken = kubeToken;
         this.namespace = namespace;
     }
@@ -48,7 +45,6 @@ public class HelmBinary {
         Map<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put("HELM_CONFIG_HOME", helmConfigPath);
         environmentVariables.put("HELM_KUBEAPISERVER", OpenShiftConfig.url());
-        environmentVariables.put("HELM_KUBEASUSER", kubeUsername);
         environmentVariables.put("HELM_KUBETOKEN", kubeToken);
         environmentVariables.put("HELM_NAMESPACE", namespace);
         environmentVariables.put("HELM_KUBEINSECURE_SKIP_TLS_VERIFY", "true");

--- a/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
@@ -16,16 +16,16 @@ class HelmBinaryManager {
     }
 
     public HelmBinary adminBinary() {
-        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.adminUsername(), OpenShiftConfig.namespace());
+        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.namespace());
     }
 
     public HelmBinary masterBinary() {
-        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.masterUsername(), OpenShiftConfig.namespace());
+        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.namespace());
     }
 
-    private static HelmBinary getBinary(String token, String username, String namespace) {
+    private static HelmBinary getBinary(String token, String namespace) {
         String helmBinaryPath = HelmBinaryManagerFactory.INSTANCE.getHelmBinaryManager().getHelmBinaryPath();
-        return new HelmBinary(helmBinaryPath, username, token, namespace);
+        return new HelmBinary(helmBinaryPath, token, namespace);
 
     }
 }

--- a/core/src/main/java/cz/xtf/core/helm/HelmBinaryPathResolver.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinaryPathResolver.java
@@ -6,7 +6,7 @@ package cz.xtf.core.helm;
 interface HelmBinaryPathResolver {
     /**
      * Resolves Helm client binary path
-     * 
+     *
      * @return Helm client binary path
      */
     String resolve();

--- a/core/src/main/java/cz/xtf/core/namespace/NamespaceManager.java
+++ b/core/src/main/java/cz/xtf/core/namespace/NamespaceManager.java
@@ -25,7 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NamespaceManager {
     /**
      * By default (xtf.openshift.namespace.per.testcase=false) all entries in map point to value returned by
-     * 
+     *
      * @see OpenShiftConfig#namespace(). If xtf.openshift.namespace.per.testcase=true then each entry points to namespace
      *      assigned to each test case by {@see NamespaceManager#getNamespaceForTestClass}
      *
@@ -116,7 +116,7 @@ public class NamespaceManager {
      * Deletes namespace as returned by @see #getNamespace
      *
      * @param waitForDeletion whether to wait for deletion (timeout 2 min)
-     * 
+     *
      * @return true if successful, false otherwise
      */
     public static boolean deleteProject(boolean waitForDeletion) {
@@ -178,7 +178,7 @@ public class NamespaceManager {
             // route suffix is: .apps.eapqe-024-dryf.eapqe.psi.redhat.com
             if ((OpenShiftConfig.namespace() + "-"
                     + testDescriptor.getParent().get().getDisplayName().toLowerCase())
-                            .length() > OpenShiftConfig.getNamespaceLengthLimitForUniqueNamespacePerTest()) {
+                    .length() > OpenShiftConfig.getNamespaceLengthLimitForUniqueNamespacePerTest()) {
 
                 return OpenShiftConfig.namespace() + "-"
                         + StringUtils.truncate(DigestUtils.sha256Hex(testDescriptor.getParent().get().getDisplayName()

--- a/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
+++ b/core/src/main/java/cz/xtf/core/openshift/ClusterVersionInfo.java
@@ -84,7 +84,7 @@ public class ClusterVersionInfo {
 
     /**
      * Detects cluster version from cluster
-     * 
+     *
      * @return version of OpenShift cluster or null
      */
     private String detectClusterVersionFromCluster() {

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -324,7 +324,7 @@ public class OpenShift extends DefaultOpenShiftClient {
 
     /**
      * Creates or recreates project specified by projectRequest instance.
-     * 
+     *
      * @param projectRequest project request instance
      * @return ProjectRequest instance
      */
@@ -1278,7 +1278,7 @@ public class OpenShift extends DefaultOpenShiftClient {
             try {
                 customResources(crdContextProvider.getContext(), GenericKubernetesResource.class,
                         GenericKubernetesResourceList.class)
-                                .inNamespace(getNamespace()).delete();
+                        .inNamespace(getNamespace()).delete();
                 log.debug("DELETE :: " + crdContextProvider.getContext().getName() + " instances");
             } catch (KubernetesClientException kce) {
                 log.debug(crdContextProvider.getContext().getName() + " might not be installed on the cluster.", kce);

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinary.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftBinary.java
@@ -34,7 +34,7 @@ public class OpenShiftBinary {
     /**
      * Apply configuration file in the specified namespace.
      * Delegates to `oc apply --filename='sourcepath' --namespace='namespace'`
-     * 
+     *
      * @param sourcePath path to configration file
      * @param namespace namespace
      */
@@ -44,7 +44,7 @@ public class OpenShiftBinary {
 
     /**
      * Apply configuration file. Delegates to `oc apply --filename='sourcepath`
-     * 
+     *
      * @param sourcePath path to configration file
      */
     public void apply(String sourcePath) {
@@ -53,7 +53,7 @@ public class OpenShiftBinary {
 
     /**
      * Apply configuration files in the order they appear in the list
-     * 
+     *
      * @param sourcePaths list of paths to configuration files
      */
     public void apply(List<String> sourcePaths) {
@@ -64,7 +64,7 @@ public class OpenShiftBinary {
 
     /**
      * Apply configuration files in the order they appear in the list, using supplied namespace.
-     * 
+     *
      * @param namespace namespace in which the configuration files should be applied
      * @param sourcePaths list of paths to configuration files
      */

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShiftWaiters.java
@@ -66,9 +66,9 @@ public class OpenShiftWaiters {
 
         return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MILLISECONDS,
                 WaitingConfig.buildTimeout(), reason)
-                        .logPoint(Waiter.LogPoint.BOTH)
-                        .failFast(failFast)
-                        .interval(5_000);
+                .logPoint(Waiter.LogPoint.BOTH)
+                .failFast(failFast)
+                .interval(5_000);
     }
 
     /**
@@ -85,9 +85,9 @@ public class OpenShiftWaiters {
 
         return new SupplierWaiter<>(supplier, "Complete"::equals, "Failed"::equals, TimeUnit.MILLISECONDS,
                 WaitingConfig.buildTimeout(), reason)
-                        .logPoint(Waiter.LogPoint.BOTH)
-                        .failFast(failFast)
-                        .interval(5_000);
+                .logPoint(Waiter.LogPoint.BOTH)
+                .failFast(failFast)
+                .interval(5_000);
     }
 
     /**
@@ -114,7 +114,7 @@ public class OpenShiftWaiters {
     public Waiter isProjectReady() {
         return new SimpleWaiter(() -> openShift.getProject() != null, TimeUnit.SECONDS, 20,
                 "Waiting for the project to be created.")
-                        .failFast(failFast);
+                .failFast(failFast);
     }
 
     /**

--- a/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogColoredPrintStream.java
+++ b/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogColoredPrintStream.java
@@ -38,7 +38,7 @@ public class ServiceLogColoredPrintStream extends PrintStream {
      * If we have e.g.: "AAAA\nBBBB", we would have 3 tokens: "AAAA","\n","BBBB";
      * Note that a buffer not containing any new line is considered a single token e.g. buffer "AAAA" is considered as
      * the single token "AAAA"
-     * 
+     *
      * @param buf the data.
      * @param off the start offset in the data.
      * @param len the number of bytes to write.
@@ -75,7 +75,7 @@ public class ServiceLogColoredPrintStream extends PrintStream {
      * Prints the line header which usually consists of the name of the container the log comes from, preceded by the
      * name of the pod and the name of the namespace where the container is running, with properly colored background
      * and foreground
-     * 
+     *
      * @throws IOException in case something goes wrong while writing to the underlying stream
      */
     private void printLineHeader() throws IOException {
@@ -92,7 +92,7 @@ public class ServiceLogColoredPrintStream extends PrintStream {
 
     /**
      * Prints a token of the log line with properly colored background and foreground
-     * 
+     *
      * @param buf the data.
      * @param off the start offset in the data.
      * @param len the number of bytes to write.
@@ -117,7 +117,7 @@ public class ServiceLogColoredPrintStream extends PrintStream {
 
     /**
      * Prints the data with properly colored background and foreground; takes care of adding a line header to each line
-     * 
+     *
      * @param buf the data.
      * @param off the start offset in the data.
      * @param len the number of bytes to write.

--- a/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogUtils.java
+++ b/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogUtils.java
@@ -10,7 +10,7 @@ public class ServiceLogUtils {
     /**
      * Adds a prefix to the message which is passed in, in order to display that it is part of the logs streaming
      * process, i.e. by adding a conventional part to the beginning of the message.
-     * 
+     *
      * @param originalMessage the original message
      * @return A string made up by the conventional prefix, followed by the original message
      */
@@ -21,7 +21,7 @@ public class ServiceLogUtils {
     /**
      * Formats the given prefix into a conventional header for a any streamed log line so that it is clear to the end
      * user that it is coming from a service log rather than from the current process one
-     * 
+     *
      * @param prefix The prefix that will be part of the header
      * @return A string representing the header for a streamed log line which will be written to the output stream
      */

--- a/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogsStreaming.java
+++ b/core/src/main/java/cz/xtf/core/service/logs/streaming/ServiceLogsStreaming.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 public @interface ServiceLogsStreaming {
     /**
      * Returns the log level filter which is set for services annotated with {@link ServiceLogsStreaming}
-     * 
+     *
      * @return A String identifying the log level filter which is set for services annotated with
      *         {@link ServiceLogsStreaming}
      */
@@ -24,7 +24,7 @@ public @interface ServiceLogsStreaming {
     /**
      * Defines the base path where log files produced by services annotated with {@link ServiceLogsStreaming} should be
      * streamed
-     * 
+     *
      * @return A String representing the base path log files produced by annotated services should be streamed.
      */
     String output() default ServiceLogsSettings.UNASSIGNED;

--- a/core/src/main/java/cz/xtf/core/service/logs/streaming/k8s/PodLogs.java
+++ b/core/src/main/java/cz/xtf/core/service/logs/streaming/k8s/PodLogs.java
@@ -93,7 +93,7 @@ public class PodLogs implements ServiceLogs {
 
         /**
          * Gets a {@link PrintStream} instance that will be passed on and used by the {@link PodLogs} instance
-         * 
+         *
          * @param printStream A {@link PrintStream} instance which will be used for streaming the service logs.
          *        It is expected that the {@link PrintStream} instance life cycle will be handled
          *        at the outer scope level, in the context and by the component which created it.

--- a/core/src/main/java/cz/xtf/core/service/logs/streaming/k8s/PodLogsWatcher.java
+++ b/core/src/main/java/cz/xtf/core/service/logs/streaming/k8s/PodLogsWatcher.java
@@ -54,7 +54,7 @@ class PodLogsWatcher implements Watcher<Pod> {
 
     /**
      * Handles newly running containers
-     * 
+     *
      * @param pod the Pod where to look for newly running containers
      */
     private void handleNewRunningContainers(Pod pod) {
@@ -128,7 +128,7 @@ class PodLogsWatcher implements Watcher<Pod> {
 
     /**
      * Handles newly terminated containers
-     * 
+     *
      * @param pod the Pod where to look for newly terminated containers
      */
     private void handleNewTerminatedContainers(Pod pod) {
@@ -189,7 +189,7 @@ class PodLogsWatcher implements Watcher<Pod> {
 
     /**
      * Gets <i>just</i> new containers statuses by filtering the existing ones out.
-     * 
+     *
      * @param before A list of {@link ContainerStatus} instances belonging to already existing containers
      * @param now A list of {@link ContainerStatus} instances belonging to new containers
      * @return A list of {@link ContainerStatus} instances representing the difference between those belonging to

--- a/core/src/main/java/cz/xtf/core/waiting/failfast/EventFailFastCheckBuilder.java
+++ b/core/src/main/java/cz/xtf/core/waiting/failfast/EventFailFastCheckBuilder.java
@@ -86,7 +86,7 @@ public class EventFailFastCheckBuilder {
 
     /**
      * If at least one event exist (after filtration), final function returns true.
-     * 
+     *
      * @return this
      */
     public FailFastBuilder atLeastOneExists() {

--- a/core/src/main/java/cz/xtf/core/waiting/failfast/FailFastBuilder.java
+++ b/core/src/main/java/cz/xtf/core/waiting/failfast/FailFastBuilder.java
@@ -14,7 +14,7 @@ import cz.xtf.core.openshift.OpenShifts;
  * If it returns true, the waiter should throw an exception.
  * <p>
  * Example of use:
- * 
+ *
  * <pre>
  * FailFastBuilder
  *         .ofTestAndBuildNamespace()

--- a/http-client/src/main/java/cz/xtf/client/HttpWaiters.java
+++ b/http-client/src/main/java/cz/xtf/client/HttpWaiters.java
@@ -42,6 +42,6 @@ public class HttpWaiters {
         };
         return new SimpleWaiter(bs,
                 "Waiting for " + client.getUrl().toExternalForm() + " to contain (" + String.join(",", strings) + ")")
-                        .timeout(WaitingConfig.timeout());
+                .timeout(WaitingConfig.timeout());
     }
 }

--- a/junit5/src/main/java/cz/xtf/junit5/extensions/ServiceLogsStreamingRunner.java
+++ b/junit5/src/main/java/cz/xtf/junit5/extensions/ServiceLogsStreamingRunner.java
@@ -160,7 +160,7 @@ public class ServiceLogsStreamingRunner implements BeforeAllCallback, AfterAllCa
     /**
      * Access the execution context {@link OutputStream} instances that represent the output of existing
      * {@link ServiceLogs} instances
-     * 
+     *
      * @param extensionContext The current test execution context
      * @return A list of {@link OutputStream} instances that represent the output of existing {@link ServiceLogs}
      *         instances

--- a/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
+++ b/junit5/src/main/java/cz/xtf/junit5/listeners/ManagedBuildPrebuilder.java
@@ -60,9 +60,9 @@ public class ManagedBuildPrebuilder implements TestExecutionListener {
         Waiter runningBuildsBelowCapacity = new SimpleWaiter(() -> buildManagerOpenShift.getBuilds().stream()
                 .filter(build -> build.getStatus() != null && "Running".equals(build.getStatus().getPhase()))
                 .count() < BuildManagerConfig.maxRunningBuilds())
-                        .timeout(TimeUnit.MILLISECONDS, WaitingConfig.timeout())
-                        .reason("Waiting for a free capacity for running builds in " + BuildManagerConfig.namespace()
-                                + " namespace.");
+                .timeout(TimeUnit.MILLISECONDS, WaitingConfig.timeout())
+                .reason("Waiting for a free capacity for running builds in " + BuildManagerConfig.namespace()
+                        + " namespace.");
 
         for (final BuildDefinition buildDefinition : buildsToBeBuilt) {
             // lazy creation, so that we don't attempt to create a buildmanager namespace when no builds defined (e.g. OSO tests)

--- a/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
+++ b/junit5/src/main/java/cz/xtf/junit5/model/DockerImageMetadata.java
@@ -91,7 +91,7 @@ public class DockerImageMetadata {
         Waiter metadataWaiter = new SimpleWaiter(
                 () -> DockerImageMetadata.areMetadataForImageReady(openShift.getImageStreamTag(tempName, image.getMajorTag())),
                 "Giving OpenShift instance time to download image metadata.")
-                        .failFast(new ImageStreamFailFastCheck(openShift, tempName, image));
+                .failFast(new ImageStreamFailFastCheck(openShift, tempName, image));
         boolean metadataOK = metadataWaiter.waitFor();
 
         // delete unique image stream and return metadata

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
         <version.maven-surefire-plugin>3.0.0-M5</version.maven-surefire-plugin>
         <version.maven-javadoc-plugin>3.2.0</version.maven-javadoc-plugin>
         <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
+        <version.maven-formatter-plugin>2.11.0</version.maven-formatter-plugin>
+        <version.maven-impsort-plugin>1.6.2</version.maven-impsort-plugin>
     </properties>
 
     <dependencyManagement>
@@ -285,7 +287,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.11.0</version>
+                <version>${version.maven-formatter-plugin}</version>
                 <configuration>
                     <configFile>${maven.multiModuleProjectDirectory}/ide-config/eclipse-format.xml</configFile>
                 </configuration>
@@ -302,12 +304,19 @@
             <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>impsort-maven-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>${version.maven-impsort-plugin}</version>
                 <configuration>
                     <groups>java.,javax.,org.,com.</groups>
                     <staticGroups>*</staticGroups>
                     <removeUnused>true</removeUnused>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-utils</artifactId>
+                        <version>3.5.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>sort-imports</id>
@@ -320,6 +329,16 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>jdk11AndLater</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <version.maven-formatter-plugin>2.22.0</version.maven-formatter-plugin>
+                <version.maven-impsort-plugin>1.8.0</version.maven-impsort-plugin>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
I have found out that combining `HELM_KUBEASUSER` and `KUBETOKEN` does not work well with `masterBinary`. Removing `HELM_KUBEASUSER` seems to solve the issue. In addition to this change, I've introduced changes needed to compile the project on Maven `3.9.1` with JDK 8 & 11. 
