### PR TITLE
HELM_KUBEASUSER removal

### DIFF
--- a/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinary.java
@@ -18,13 +18,11 @@ public class HelmBinary {
 
     private final String path;
     private final String helmConfigPath;
-    private final String kubeUsername;
     private final String kubeToken;
     private final String namespace;
 
-    public HelmBinary(String path, String kubeUsername, String kubeToken, String namespace) {
+    public HelmBinary(String path, String kubeToken, String namespace) {
         this.path = path;
-        this.kubeUsername = kubeUsername;
         this.kubeToken = kubeToken;
         Path helmConfigFile = Paths.get(path).getParent().resolve(".config");
         try {
@@ -39,7 +37,6 @@ public class HelmBinary {
     public HelmBinary(String path, String helmConfigPath, String kubeUsername, String kubeToken, String namespace) {
         this.path = path;
         this.helmConfigPath = helmConfigPath;
-        this.kubeUsername = kubeUsername;
         this.kubeToken = kubeToken;
         this.namespace = namespace;
     }
@@ -48,7 +45,6 @@ public class HelmBinary {
         Map<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put("HELM_CONFIG_HOME", helmConfigPath);
         environmentVariables.put("HELM_KUBEAPISERVER", OpenShiftConfig.url());
-        environmentVariables.put("HELM_KUBEASUSER", kubeUsername);
         environmentVariables.put("HELM_KUBETOKEN", kubeToken);
         environmentVariables.put("HELM_NAMESPACE", namespace);
         environmentVariables.put("HELM_KUBEINSECURE_SKIP_TLS_VERIFY", "true");

--- a/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
@@ -16,16 +16,16 @@ class HelmBinaryManager {
     }
 
     public HelmBinary adminBinary() {
-        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.adminUsername(), OpenShiftConfig.namespace());
+        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.namespace());
     }
 
     public HelmBinary masterBinary() {
-        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.masterUsername(), OpenShiftConfig.namespace());
+        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.namespace());
     }
 
-    private static HelmBinary getBinary(String token, String username, String namespace) {
+    private static HelmBinary getBinary(String token, String namespace) {
         String helmBinaryPath = HelmBinaryManagerFactory.INSTANCE.getHelmBinaryManager().getHelmBinaryPath();
-        return new HelmBinary(helmBinaryPath, username, token, namespace);
+        return new HelmBinary(helmBinaryPath, token, namespace);
 
     }
 }


### PR DESCRIPTION
I have found out that combining `HELM_KUBEASUSER` and `KUBETOKEN` does not work well with `masterBinary`. Removing `HELM_KUBEASUSER` seems to solve the issue

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
