### PR TITLE
Fix configMapKeyRef: name and key are inverted

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/ContainerBuilder.java
@@ -368,7 +368,7 @@ public class ContainerBuilder implements EnvironmentConfiguration, ResourceLimit
 
     public ContainerBuilder configFromConfigMap(String configMapName, Function<String, String> nameMapping,
             Collection<String> configMapKeys) {
-        configMapKeys.forEach(x -> referredEnvVars.put(nameMapping.apply(x), new Entry(configMapName, x)));
+        configMapKeys.forEach(x -> referredEnvVars.put(nameMapping.apply(x), new Entry(x, configMapName)));
         return this;
     }
 


### PR DESCRIPTION
This MR fixed the `DeploymentConfig` produced by `ContainerBuilder`:
At present key and name are inverted:
```
        - name: POSTGRESQL_ADMIN_PASSWORD
          valueFrom:
            configMapKeyRef:
              name: postgresql-admin-password
              key: postgresql
        - name: POSTGRESQL_PASSWORD
          valueFrom:
            configMapKeyRef:
              name: postgresql-password
              key: postgresql
        - name: POSTGRESQL_USER
          valueFrom:
            configMapKeyRef:
              name: postgresql-user
              key: postgresql
```

with this MR, the correct output is 
```
        - name: POSTGRESQL_ADMIN_PASSWORD
          valueFrom:
            configMapKeyRef:
              name: postgresql
              key: postgresql-admin-password
        - name: POSTGRESQL_PASSWORD
          valueFrom:
            configMapKeyRef:
              name: postgresql
              key: postgresql-password
        - name: POSTGRESQL_USER
          valueFrom:
            configMapKeyRef:
              name: postgresql
              key: postgresql-user
```


Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
