### PR TITLE
Fix DeploymentConfig and BuildConfig update

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -766,7 +766,7 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
     }
 
     public DeploymentConfig updateDeploymentconfig(DeploymentConfig deploymentConfig) {
-        return deploymentConfigs().withName(deploymentConfig.getMetadata().getName()).replace();
+        return deploymentConfigs().withName(deploymentConfig.getMetadata().getName()).replace(deploymentConfig);
     }
 
     /**
@@ -876,7 +876,7 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
     }
 
     public BuildConfig updateBuildConfig(BuildConfig buildConfig) {
-        return buildConfigs().withName(buildConfig.getMetadata().getName()).replace();
+        return buildConfigs().withName(buildConfig.getMetadata().getName()).replace(buildConfig);
     }
 
     /**


### PR DESCRIPTION
Fixed null pointer reference when updating Deployment configs in javaopts tests. Same should apply to Buildconfigs.