### PR TITLE
Workaround for the issue when tar executed in docker container

### DIFF
--- a/core/src/main/java/cz/xtf/core/helm/ConfiguredVersionHelmBinaryPathResolver.java
+++ b/core/src/main/java/cz/xtf/core/helm/ConfiguredVersionHelmBinaryPathResolver.java
@@ -44,9 +44,11 @@ class ConfiguredVersionHelmBinaryPathResolver implements HelmBinaryPathResolver 
         Objects.requireNonNull(archivePath);
 
         try {
+            // --no-same-owner argument is added for the docker container execution where tar gets wrong ownership information
+            // due to the context of the builder
             List<String> args = Stream
                     .of("tar", "-xf", archivePath.toAbsolutePath().toString(), "-C",
-                            getProjectHelmDir().toAbsolutePath().toString())
+                            getProjectHelmDir().toAbsolutePath().toString(), "--no-same-owner")
                     .collect(Collectors.toList());
             ProcessBuilder pb = new ProcessBuilder(args);
 


### PR DESCRIPTION
When running tar in a docker container we face an issue https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233. Tar is used for unpacking the helm binary by the ConfiguredVersionHelmBinaryPathResolver.

7.4.x branch with the 0.30 SNAPSHOT test run https://cp-jenkins.eapqe.psi.redhat.com/job/eap-74x-openshift-4-xp4-openjdk11/125/.