### PR TITLE
Fix getAnyPod throwing IllegalArgumentException when no pod found

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -556,8 +556,18 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
         return getAnyPod(Collections.singletonMap(key, value));
     }
 
+    /**
+     * Returns random pod with specified labels
+     * 
+     * @param labels labels to be used for filtering
+     * @return random pod with specified labels
+     * @throws RuntimeException if no pod is found
+     */
     public Pod getAnyPod(Map<String, String> labels) {
         List<Pod> pods = getLabeledPods(labels);
+        if (pods.isEmpty()) {
+            throw new RuntimeException("No pod found with labels: " + labels);
+        }
         return pods.get(new Random().nextInt(pods.size()));
     }
 


### PR DESCRIPTION
Fix getAnyPod throwing IllegalArgumentException when no pod with specified labels is found.

Now it throws an explained RuntimeException.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
