### PR TITLE
Set Oracle data dir back to /var/lib/oracle/data from /opt/oracle/ora…

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/AbstractOracle.java
+++ b/builder/src/main/java/cz/xtf/builder/db/AbstractOracle.java
@@ -29,7 +29,7 @@ public abstract class AbstractOracle extends AbstractSQLDatabase {
     protected static final String PASSWORD = "oracle";
     protected static String DB_NAME;
     protected static final String SYMBOLIC_NAME = "ORACLE";
-    protected static final String DATA_DIR = "/opt/oracle/oradata";
+    protected static final String DATA_DIR = "/var/lib/oracle/data";
 
     public AbstractOracle(String dbName) {
         super(USERNAME, PASSWORD, dbName, SYMBOLIC_NAME, DATA_DIR);


### PR DESCRIPTION
…data to speed up Oracle DB start.

@liborfuka fyi I've tried Oracle FREE and started significantly faster as well. So this should work for both Oracle FREE and Oracle XE.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
