### PR TITLE
sqlcmd path updated for the newest MsSQL image

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/MsSQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/MsSQL.java
@@ -94,11 +94,11 @@ public class MsSQL extends AbstractSQLDatabase {
         return new ProbeSettings(30,
                 String.valueOf(this.getPort()),
                 5,
-                "/opt/mssql-tools/bin/sqlcmd -S localhost -d " + getDbName() + " -U " + getUsername() + " -P " + getPassword()
-                        + " -Q \"Select 1\"",
+                "/opt/mssql-tools18/bin/sqlcmd -S localhost -d " + getDbName() + " -U " + getUsername() + " -P " + getPassword()
+                        + " -C -Q \"Select 1\"",
                 5,
-                "/opt/mssql-tools/bin/sqlcmd -S localhost -d " + getDbName() + " -U " + getUsername() + " -P " + getPassword()
-                        + " -Q \"Select 1\"",
+                "/opt/mssql-tools18/bin/sqlcmd -S localhost -d " + getDbName() + " -U " + getUsername() + " -P " + getPassword()
+                        + " -C -Q \"Select 1\"",
                 10,
                 10);
     }


### PR DESCRIPTION
In the latest MSSQL Docker image (2022-latest refering to 2022-CU14-ubuntu-20.04) the path to sqlcmd was changed. This causes probe error during the start.

Tracked by [the mssql-docker issue](https://github.com/microsoft/mssql-docker/issues/892).

Related XTF issue https://github.com/xtf-cz/xtf/issues/573.