### PR TITLE
[#572] Allow image url with more than 2 slashes to be parsed properly.

### DIFF
--- a/core/src/main/java/cz/xtf/core/image/Image.java
+++ b/core/src/main/java/cz/xtf/core/image/Image.java
@@ -1,6 +1,7 @@
 package cz.xtf.core.image;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import cz.xtf.core.config.XTFConfig;
@@ -70,7 +71,10 @@ public class Image {
                 repoTag = slashTokens[2];
                 break;
             default:
-                throw new IllegalArgumentException("image '" + imageUrl + "' should have one or two '/' characters");
+                registry = slashTokens[0];
+                user = slashTokens[1];
+                repoTag = String.join("/", Arrays.copyOfRange(slashTokens, 2, slashTokens.length));
+                break;
         }
 
         final String[] tokens = repoTag.split(":");

--- a/core/src/test/java/cz/xtf/core/image/ImageTest.java
+++ b/core/src/test/java/cz/xtf/core/image/ImageTest.java
@@ -99,4 +99,50 @@ public class ImageTest {
         Assertions.assertThrows(UnknownImageException.class, () -> Image.resolve("blabla"),
                 "Expected UnknownImageException to be thrown for unknown image.");
     }
+
+    @Test
+    public void testImageFromUrlOneToken() {
+        Image image = Image.from("nginx");
+        Assertions.assertTrue(image.getRegistry().isEmpty(), "Registry for image url: 'nginx' must be empty.");
+        Assertions.assertTrue(image.getUser().isEmpty(), "User for image url: 'nginx' must be empty.");
+        Assertions.assertEquals("nginx", image.getRepo(), "Wrong repository name.");
+        Assertions.assertTrue(image.getTag().isEmpty(), "Tag for image url: 'nginx' must be empty.");
+    }
+
+    @Test
+    public void testImageFromUrlTwoTokens() {
+        Image image = Image.from("user/nginx");
+        Assertions.assertTrue(image.getRegistry().isEmpty(), "Registry for image url: 'user/nginx' must be empty.");
+        Assertions.assertEquals("user", image.getUser(), "User for image url: 'user/nginx' is wrong.");
+        Assertions.assertEquals("nginx", image.getRepo(), "Wrong repository name.");
+        Assertions.assertTrue(image.getTag().isEmpty(), "Tag for image url: 'user/nginx' must be empty.");
+    }
+
+    @Test
+    public void testImageFromUrlThreeTokens() {
+        Image image = Image.from("quay.io/jaegertracing/all-in-one:1.56");
+        Assertions.assertEquals("quay.io", image.getRegistry(), "Wrong registry parsed from image url.");
+        Assertions.assertEquals("jaegertracing", image.getUser(), "Wrong user parsed from image url.");
+        Assertions.assertEquals("all-in-one", image.getRepo(), "Wrong repository name.");
+        Assertions.assertEquals("1.56", image.getTag(), "Wrong tag parsed from image url.");
+    }
+
+    @Test
+    public void testImageFromUrlFourTokens() {
+        Image image = Image.from("mcr.microsoft.com/mssql/rhel/server:2022-CU13-rhel-9.1");
+        Assertions.assertEquals("mcr.microsoft.com", image.getRegistry(), "Wrong registry parsed from image url.");
+        Assertions.assertEquals("mssql", image.getUser(), "Wrong user parsed from image url.");
+        Assertions.assertEquals("rhel/server", image.getRepo(), "Wrong repository name.");
+        Assertions.assertEquals("2022-CU13-rhel-9.1", image.getTag(), "Wrong tag parsed from image url.");
+    }
+
+    @Test
+    public void testImageFromUrlFourPlusTokens() {
+        Image image = Image.from("mycompany.registry.com/user/team-b/subteam-c/myservice/subservice/subsubservice:1.2.3");
+        Assertions.assertEquals("mycompany.registry.com", image.getRegistry(), "Wrong registry parsed from image url.");
+        Assertions.assertEquals("user", image.getUser(), "Wrong user parsed from image url.");
+        Assertions.assertEquals("team-b/subteam-c/myservice/subservice/subsubservice", image.getRepo(),
+                "Wrong repository name.");
+        Assertions.assertEquals("1.2.3", image.getTag(), "Wrong tag parsed from image url.");
+    }
 }


### PR DESCRIPTION
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented

CI runs:  
Without fix: https://url.corp.redhat.com/a7db151
With fix: https://url.corp.redhat.com/bbed950
* GalleonDatasourceNoDriverVersionTest#noMsSQLDriverVersion,GalleonDatasourceFeaturePackMsSQLTest - caused by not updated mssql image
* Rerun HAServletCounterUpstreamKubePingTest,RollingUpdatesKubePingTest → https://url.corp.redhat.com/e8c1138 passed
