### PR TITLE
image URL without tag formatted by Image object shouldn't have trailing colon

### DIFF
--- a/core/src/main/java/cz/xtf/core/image/Image.java
+++ b/core/src/main/java/cz/xtf/core/image/Image.java
@@ -100,7 +100,7 @@ public class Image {
     private final String tag;
 
     public Image(String registry, String user, String repo, String tag) {
-        this.url = String.format("%s/%s/%s:%s", registry, user, repo, tag);
+        this.url = String.format(tag.trim().isEmpty() ? "%s/%s/%s" : "%s/%s/%s:%s", registry, user, repo, tag);
         this.registry = registry;
         this.user = user;
         this.repo = repo;

--- a/core/src/test/java/cz/xtf/core/image/ImageTest.java
+++ b/core/src/test/java/cz/xtf/core/image/ImageTest.java
@@ -125,6 +125,18 @@ public class ImageTest {
         Assertions.assertEquals("jaegertracing", image.getUser(), "Wrong user parsed from image url.");
         Assertions.assertEquals("all-in-one", image.getRepo(), "Wrong repository name.");
         Assertions.assertEquals("1.56", image.getTag(), "Wrong tag parsed from image url.");
+        Assertions.assertEquals("quay.io/jaegertracing/all-in-one:1.56", image.getUrl(),
+                "Wrong url generated from image object.");
+    }
+
+    @Test
+    public void testImageFromUrlThreeTokensNoTag() {
+        Image image = Image.from("quay.io/jaegertracing/all-in-one");
+        Assertions.assertEquals("quay.io", image.getRegistry(), "Wrong registry parsed from image url.");
+        Assertions.assertEquals("jaegertracing", image.getUser(), "Wrong user parsed from image url.");
+        Assertions.assertEquals("all-in-one", image.getRepo(), "Wrong repository name.");
+        Assertions.assertEquals("", image.getTag(), "Wrong tag parsed from image url.");
+        Assertions.assertEquals("quay.io/jaegertracing/all-in-one", image.getUrl(), "Wrong url generated from image object.");
     }
 
     @Test


### PR DESCRIPTION
Before this the returned URL was `quay.io/jaegertracing/all-in-one:1.56:`.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
