### PR TITLE
Fix MySQL Data Directory

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/MySQL.java
+++ b/builder/src/main/java/cz/xtf/builder/db/MySQL.java
@@ -1,36 +1,40 @@
 package cz.xtf.builder.db;
 
 import cz.xtf.builder.builders.pod.PersistentVolumeClaim;
+import cz.xtf.core.config.XTFConfig;
 import cz.xtf.core.image.Image;
 
 public class MySQL extends AbstractSQLDatabase {
 
+    private static final String DATA_DIR_PROPERTY = "xtf.mysql.datadir";
+    private static final String MYSQL_DATA_DIR = XTFConfig.get(DATA_DIR_PROPERTY, "/var/lib/mysql/data");
+
     public MySQL() {
-        super("MYSQL", "/var/lib/mysql/data");
+        super("MYSQL", MYSQL_DATA_DIR);
     }
 
     public MySQL(boolean withLivenessProbe, boolean withReadinessProbe) {
-        super("MYSQL", "/var/lib/mysql/data", withLivenessProbe, withReadinessProbe);
+        super("MYSQL", MYSQL_DATA_DIR, withLivenessProbe, withReadinessProbe);
     }
 
     public MySQL(boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
-        super("MYSQL", "/var/lib/mysql/data", withLivenessProbe, withReadinessProbe, withStartupProbe, true);
+        super("MYSQL", MYSQL_DATA_DIR, withLivenessProbe, withReadinessProbe, withStartupProbe, true);
     }
 
     public MySQL(PersistentVolumeClaim pvc) {
-        super("MYSQL", "/var/lib/mysql/data", pvc);
+        super("MYSQL", MYSQL_DATA_DIR, pvc);
     }
 
     public MySQL(PersistentVolumeClaim pvc, boolean withLivenessProbe, boolean withReadinessProbe) {
-        super("MYSQL", "/var/lib/mysql/data", pvc, withLivenessProbe, withReadinessProbe);
+        super("MYSQL", MYSQL_DATA_DIR, pvc, withLivenessProbe, withReadinessProbe);
     }
 
     public MySQL(PersistentVolumeClaim pvc, boolean withLivenessProbe, boolean withReadinessProbe, boolean withStartupProbe) {
-        super("MYSQL", "/var/lib/mysql/data", pvc, withLivenessProbe, withReadinessProbe, withStartupProbe);
+        super("MYSQL", MYSQL_DATA_DIR, pvc, withLivenessProbe, withReadinessProbe, withStartupProbe);
     }
 
     public MySQL(String username, String password, String dbName) {
-        super(username, password, dbName, "MYSQL", "/var/lib/mysql/data");
+        super(username, password, dbName, "MYSQL", MYSQL_DATA_DIR);
     }
 
     @Override


### PR DESCRIPTION
Fix issues-588 by setting the correct MySQL Data Directory;

Now you can use both the following images by setting the correct `datadir`:

```
xtf.mysql.image=registry.redhat.io/rhel9/mysql-80:latest
# the following value is the default value and can be omitted
xtf.mysql.datadir=/var/lib/mysql/data
```

or:

```
xtf.mysql.image=container-registry.oracle.com/mysql/community-server:8.0
xtf.mysql.datadir=/var/lib/mysql
```

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
