### PR TITLE
[#599] Add RHEL9 Red Hat, Inc. (auxiliary key 3) GPG key

### DIFF
--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -232,7 +232,7 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
 
     /**
      * Convenient method to create pull secret for authenticated image registries.
-     * The secret content must be provided in "dockerconfigjson" formar.
+     * The secret content must be provided in "dockerconfigjson" format.
      *
      * E.g.: {@code {"auths":{"registry.redhat.io":{"auth":"<REDACTED_TOKEN>"}}}}
      *

--- a/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
+++ b/test-helpers/src/main/java/cz/xtf/testhelpers/image/ImageContent.java
@@ -26,6 +26,7 @@ public class ImageContent {
     public static final String RED_HAT_RELEASE_KEY_2_RPM = "gpg-pubkey-fd431d51-4ae0493b";
     public static final String RED_HAT_AUXILIARY_KEY_RPM = "gpg-pubkey-2fa658e0-45700c69";
     public static final String RED_HAT_AUXILIARY_KEY_2_RPM = "gpg-pubkey-d4082792-5b32db75";
+    public static final String RED_HAT_AUXILIARY_KEY_3_RPM = "gpg-pubkey-5a6340b3-6229229e";
     public static final String[] DEFAULT_JAVA_UTILITIES = new String[] { "jjs", "keytool", "orbd", "rmid", "rmiregistry",
             "servertool", "tnameserv", "unpack200", "javac", "appletviewer", "extcheck", "idlj", "jar", "jarsigner",
             "javadoc", "javah", "javap", "jcmd", "jconsole", "jdb", "jdeps", "jhat", "jinfo", "jmap", "jps",


### PR DESCRIPTION
Similary to https://github.com/xtf-cz/xtf/pull/280 addressing RHEL8 we would need provide update for RHEL9 as well.

In RHEL9 Red Hat, Inc. (auxiliary key 3) from https://access.redhat.com/security/team/key is used as backup key

CI runs are here [https://url.corp.redhat.com/066cc99](https://url.corp.redhat.com/066cc99)

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
