### PR TITLE
Change url for snaphost/release maven repo for distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <repository>
             <id>jboss-releases-repository</id>
             <name>JBoss Releases Repository</name>
-            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2</url>
+            <url>https://repository.jboss.org/nexus/repository/jbossqe-eap</url>
         </repository>
         <snapshotRepository>
             <id>jboss-snapshots-repository</id>
             <name>JBoss Snapshots Repository</name>
-            <url>https://repository.jboss.org/nexus/content/repositories/snapshots</url>
+            <url>https://repository.jboss.org/nexus/repository/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
Upload to snapshots repo: https://github.com/mnovak/xtf/actions/runs/17068010578/job/48389691987
Deploy to release maven repo will require more changes as described in: https://docs.google.com/document/d/1-6_vmFWzRVuMRwSuv_nOgG530qSDe6Ipc_eCERv6lrE/edit?pli=1&tab=t.0 (tracked in the issue: https://github.com/xtf-cz/xtf/issues/609)