### PR TITLE
Unify repository id with other usages

### DIFF
--- a/.github/workflows/xtf-maven-release.yml
+++ b/.github/workflows/xtf-maven-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v12
         with:
-          servers: '[{ "id": "jboss-releases-repository", "username": "${env.JBOSS_REPO_USER}", "password": "${env.JBOSS_REPO_PASSWORD}" },{ "id": "jboss-snapshots-repository", "username": "${env.JBOSS_REPO_USER}", "password": "${env.JBOSS_REPO_PASSWORD}" }]'
+          servers: '[{ "id": "jbossqe-eap-releases-repository", "username": "${env.JBOSS_REPO_USER}", "password": "${env.JBOSS_REPO_PASSWORD}" },{ "id": "jboss-snapshots-repository", "username": "${env.JBOSS_REPO_USER}", "password": "${env.JBOSS_REPO_PASSWORD}" }]'
       - name: Import GPG Key
         uses: crazy-max/ghaction-import-gpg@v1
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
     <distributionManagement>
         <repository>
-            <id>jboss-releases-repository</id>
-            <name>JBoss Releases Repository</name>
+            <id>jbossqe-eap-releases-repository</id>
+            <name>JBoss QE EAP Releases Repository</name>
             <url>https://repository.jboss.org/nexus/repository/jbossqe-eap/</url>
         </repository>
         <snapshotRepository>


### PR DESCRIPTION
Please make sure your PR meets the following requirements:
- [ x Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented

## Summary by Sourcery

Unify the repository identifier across the project by renaming the Maven distributionManagement repository and updating the CI configuration accordingly.

Build:
- Update distributionManagement repository id to 'jbossqe-eap-releases-repository' and adjust its name in pom.xml

CI:
- Update maven-settings-xml-action configuration to use the new repository id in the GitHub Actions workflow