### PR TITLE
Bump Fabric8 OpenShift client to 6.14.0 (last minor in 6.x)

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/db/AbstractSQLDatabase.java
+++ b/builder/src/main/java/cz/xtf/builder/db/AbstractSQLDatabase.java
@@ -1,6 +1,5 @@
 package cz.xtf.builder.db;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.function.Consumer;
@@ -109,17 +108,13 @@ public abstract class AbstractSQLDatabase extends AbstractDatabase implements SQ
 
     public void executeSQLFile(String resourceName) {
         executeSQL(db -> {
-            try {
-                IOUtils.readLines(AbstractSQLDatabase.class.getResourceAsStream(resourceName)).forEach(x -> {
-                    try {
-                        db.createStatement().execute(x);
-                    } catch (SQLException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                });
-            } catch (final IOException e) {
-                throw new IllegalStateException(e);
-            }
+            IOUtils.readLines(AbstractSQLDatabase.class.getResourceAsStream(resourceName)).forEach(x -> {
+                try {
+                    db.createStatement().execute(x);
+                } catch (SQLException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            });
         });
     }
 

--- a/builder/src/main/java/cz/xtf/builder/db/SQLExecutorImpl.java
+++ b/builder/src/main/java/cz/xtf/builder/db/SQLExecutorImpl.java
@@ -1,6 +1,5 @@
 package cz.xtf.builder.db;
 
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -33,17 +32,13 @@ public class SQLExecutorImpl implements SQLExecutor {
     @Override
     public void executeSQLFile(String resourceName) {
         executeSQL(db -> {
-            try {
-                IOUtils.readLines(SQLExecutorImpl.class.getResourceAsStream(resourceName)).forEach(x -> {
-                    try {
-                        db.createStatement().execute(x);
-                    } catch (SQLException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                });
-            } catch (final IOException e) {
-                throw new IllegalStateException(e);
-            }
+            IOUtils.readLines(SQLExecutorImpl.class.getResourceAsStream(resourceName)).forEach(x -> {
+                try {
+                    db.createStatement().execute(x);
+                } catch (SQLException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            });
         });
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <!-- Dependency version properties -->
         <version.httpclient>4.5.13</version.httpclient>
         <version.openshift-client>6.14.0</version.openshift-client>
-        <version.commons-io>2.8.0</version.commons-io>
+        <version.commons-io>2.15.1</version.commons-io>
         <version.commons-lang3>3.11</version.commons-lang3>
         <version.commons-compress>1.26.0</version.commons-compress>
         <version.commons-codec>1.15</version.commons-codec>


### PR DESCRIPTION
As described in #616, the Fabric8 OpenSHift client version is obsolete.
I had to bump the version in Intersmash as well, in order to avoid https://github.com/fabric8io/kubernetes-client/issues/5580.
After that I am blocked by incompatibilities in XTF, which requires 6.8.1 at runtime.

I am providing this PR to use the last minor in the 6.x stream, since upgrading to 7.x would require more work, and would affect downstream projects (Intersmash, OpenShift test suites) heavily.

Tests are passing locally.

FYI @mchoma, @mnovak

---
Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented
