### PR TITLE
[issue_624] Add configurable memory requests and limits for BuildConfigs

### DIFF
--- a/core/src/main/java/cz/xtf/core/bm/BinaryBuildFromSources.java
+++ b/core/src/main/java/cz/xtf/core/bm/BinaryBuildFromSources.java
@@ -61,6 +61,11 @@ abstract public class BinaryBuildFromSources extends BinaryBuild {
         super(builderImage, path, envProperties, id);
     }
 
+    public BinaryBuildFromSources(String builderImage, Path path, Map<String, String> envProperties, String id,
+            String memoryRequest, String memoryLimit) {
+        super(builderImage, path, envProperties, id, memoryRequest, memoryLimit);
+    }
+
     @Override
     public void build(OpenShift openShift) {
         openShift.imageStreams().create(is);

--- a/core/src/main/java/cz/xtf/core/config/BuildManagerConfig.java
+++ b/core/src/main/java/cz/xtf/core/config/BuildManagerConfig.java
@@ -5,6 +5,8 @@ public class BuildManagerConfig {
     public static final String FORCE_REBUILD = "xtf.bm.force_rebuild";
     public static final String SKIP_REBUILD = "xtf.bm.skip_rebuild";
     public static final String MAX_RUNNING_BUILDS = "xtf.bm.max_running_builds";
+    public static final String MEMORY_REQUEST = "xtf.bm.memory.request";
+    public static final String MEMORY_LIMIT = "xtf.bm.memory.limit";
 
     public static String namespace() {
         return XTFConfig.get(BUILD_NAMESPACE, "xtf-builds");
@@ -20,5 +22,23 @@ public class BuildManagerConfig {
 
     public static int maxRunningBuilds() {
         return Integer.valueOf(XTFConfig.get(MAX_RUNNING_BUILDS, "5"));
+    }
+
+    /**
+     * Memory request for builds (e.g., "2Gi", "512Mi")
+     *
+     * @return memory request string or null if not configured
+     */
+    public static String memoryRequest() {
+        return XTFConfig.get(MEMORY_REQUEST);
+    }
+
+    /**
+     * Memory limit for builds (e.g., "4Gi", "1Gi")
+     *
+     * @return memory limit string or null if not configured
+     */
+    public static String memoryLimit() {
+        return XTFConfig.get(MEMORY_LIMIT);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for configuring memory resource requirements on BuildConfigs through XTF configuration properties.

## Changes

- **BuildManagerConfig**: Added `xtf.bm.memory.request` and `xtf.bm.memory.limit` configuration properties
- **BinaryBuild**: Updated to apply ResourceRequirements when creating BuildConfig spec
- **BinarySourceBuild**: Extended constructor to accept memory parameters
- **BinaryBuildTest**: Added comprehensive tests for memory configuration scenarios
- **CLAUDE.md**: Added project guidelines for AI-assisted development

## Usage

Configure memory limits in `test.properties` or `global-test.properties`:

```properties
# Set build memory request to 2GB
xtf.bm.memory.request=2Gi

# Set build memory limit to 4GB
xtf.bm.memory.limit=4Gi
```

## Backward Compatibility

Memory configuration is **optional and backward compatible**. When properties are not set, builds work as before without resource constraints.

## Testing

All existing tests pass, and new tests verify:
- Both request and limit set correctly
- Only request set (limit null)
- Only limit set (request null)
- No memory config (resources null)

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of the current user

## Summary by Sourcery

Add configurable memory resource settings to binary builds via XTF configuration properties, update build logic to apply and detect resource constraints, include tests for various memory scenarios and error statuses, and provide AI-assisted development guidelines.

New Features:
- Support optional memory requests and limits for BuildConfigs via xtf.bm.memory.request and xtf.bm.memory.limit properties

Bug Fixes:
- Consider builds in "Error" status as failed in needsUpdate logic

Enhancements:
- Propagate memory configuration through BinaryBuild constructors and apply ResourceRequirements in BuildConfig spec
- Add io.fabric8 openshift-server-mock dependency to the core module

Documentation:
- Introduce CLAUDE.md guidelines for AI-assisted development

Tests:
- Add BinaryBuildTest covering memory request/limit scenarios and build status handling