### PR TITLE
[issue_627] Fail fast when OpenShift admin token is not configured for Helm

### DIFF
--- a/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
+++ b/core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java
@@ -16,11 +16,25 @@ class HelmBinaryManager {
     }
 
     public HelmBinary adminBinary() {
-        return getBinary(OpenShiftConfig.adminToken(), OpenShiftConfig.namespace());
+        String adminToken = validateToken(
+                OpenShiftConfig.adminToken(),
+                OpenShiftConfig.OPENSHIFT_ADMIN_TOKEN);
+        return getBinary(adminToken, OpenShiftConfig.namespace());
     }
 
     public HelmBinary masterBinary() {
-        return getBinary(OpenShiftConfig.masterToken(), OpenShiftConfig.namespace());
+        String masterToken = validateToken(
+                OpenShiftConfig.masterToken(),
+                OpenShiftConfig.OPENSHIFT_MASTER_TOKEN);
+        return getBinary(masterToken, OpenShiftConfig.namespace());
+    }
+
+    private String validateToken(String token, String propertyName) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalStateException(
+                    "Token is not configured. Please set '" + propertyName + "' in your properties file.");
+        }
+        return token;
     }
 
     private static HelmBinary getBinary(String token, String namespace) {


### PR DESCRIPTION
## Description

This PR addresses issue #627 by adding validation in `HelmBinaryManager` to fail fast when the OpenShift admin token is not configured for Helm operations. This provides clearer error feedback instead of allowing operations to proceed and fail later with less informative error messages.

## Changes
- Added validation check in `HelmBinaryManager.java` to verify OpenShift admin token is configured before proceeding with Helm operations
- Modified file: `core/src/main/java/cz/xtf/core/helm/HelmBinaryManager.java`

## Checklist
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [ ] Code is formatted, imports ordered, code compiles and tests are passing
- [ ] Code is self-descriptive and/or documented

## Summary by Sourcery

Bug Fixes:
- Add validation to prevent Helm admin and master operations from proceeding when the corresponding OpenShift tokens are not configured.