### PR TITLE
Endpoints write permissions removed in OCP 4.21

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/OpenShiftApplication.java
+++ b/builder/src/main/java/cz/xtf/builder/OpenShiftApplication.java
@@ -11,7 +11,6 @@ import cz.xtf.core.openshift.OpenShiftWaiters;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.core.waiting.failfast.FailFastCheck;
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.Endpoints;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
@@ -37,7 +36,6 @@ public class OpenShiftApplication {
     private List<PersistentVolumeClaim> persistentVolumeClaims = new LinkedList<>();
     private List<DeploymentConfig> deploymentConfigs = new LinkedList<>();
     private List<Service> services = new LinkedList<>();
-    private List<Endpoints> endpoints = new LinkedList<>();
     private List<Route> routes = new LinkedList<>();
     private List<ConfigMap> configMaps = new LinkedList<>();
     private List<HorizontalPodAutoscaler> autoScalers = new LinkedList<>();
@@ -120,7 +118,6 @@ public class OpenShiftApplication {
                 .filter(x -> !x.getMetadata().getLabels().containsKey(DeploymentConfigBuilder.SYNCHRONOUS_LABEL))
                 .map(openShift::createDeploymentConfig).collect(Collectors.toList());
         deploymentConfigs.addAll(syncDeployments);
-        endpoints = endpoints.stream().map(openShift::createEndpoint).collect(Collectors.toList());
         routes = routes.stream().map(openShift::createRoute).collect(Collectors.toList());
         configMaps = configMaps.stream().map(openShift::createConfigMap).collect(Collectors.toList());
         autoScalers = autoScalers.stream().map(openShift::createHorizontalPodAutoscaler).collect(Collectors.toList());

--- a/builder/src/main/java/cz/xtf/builder/builders/EndpointBuilder.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/EndpointBuilder.java
@@ -12,6 +12,14 @@ import io.fabric8.kubernetes.api.model.Endpoints;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * @deprecated since v1.1. This class is scheduled for removal in v2.0
+ *             Endpoints were deprecated in Kubernetes v1.33.
+ *             <p>
+ *             Use {@link io.fabric8.kubernetes.api.model.discovery.v1.EndpointSlice}
+ * @see <a href=https://kubernetes.io/docs/reference/access-authn-authz/rbac/#write-access-for-endpoints>Write access for
+ *      endpoints</a>
+ */
 public class EndpointBuilder extends AbstractBuilder<Endpoints, EndpointBuilder> {
     private final List<String> endpointIPs = new ArrayList<>();
     private final List<Port> ports = new ArrayList<>();

--- a/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
+++ b/core/src/main/java/cz/xtf/core/openshift/OpenShift.java
@@ -558,7 +558,7 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
 
     /**
      * Returns random pod with specified labels
-     * 
+     *
      * @param labels labels to be used for filtering
      * @return random pod with specified labels
      * @throws RuntimeException if no pod is found
@@ -673,6 +673,14 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
     }
 
     // Endpoints
+    /**
+     * Needs a role with write permissions see
+     * <a href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#write-access-for-endpoints">Endpoint write
+     * access</a>
+     *
+     * @param endpoint
+     * @return Endpoints created
+     */
     public Endpoints createEndpoint(Endpoints endpoint) {
         return endpoints().resource(endpoint).create();
     }
@@ -685,6 +693,14 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
         return endpoints().list().getItems();
     }
 
+    /**
+     * Needs a role with write permissions see
+     * <a href="https://kubernetes.io/docs/reference/access-authn-authz/rbac/#write-access-for-endpoints">Endpoint write
+     * access</a>
+     *
+     * @param endpoint
+     * @return True if Endpoint was deleted
+     */
     public boolean deleteEndpoint(Endpoints endpoint) {
         return !endpoints().resource(endpoint).delete().isEmpty();
     }
@@ -1314,7 +1330,6 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
         replicationControllers().withLabelNotIn(KEEP_LABEL, "", "true").delete();
         buildConfigs().withLabelNotIn(KEEP_LABEL, "", "true").delete();
         imageStreams().withLabelNotIn(KEEP_LABEL, "", "true").delete();
-        endpoints().withLabelNotIn(KEEP_LABEL, "", "true").delete();
         services().withLabelNotIn(KEEP_LABEL, "", "true").delete();
         builds().withLabelNotIn(KEEP_LABEL, "", "true").delete();
         routes().withLabelNotIn(KEEP_LABEL, "", "true").delete();
@@ -1350,7 +1365,6 @@ public class OpenShift extends NamespacedOpenShiftClientAdapter {
         removables.addAll(replicationControllers().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
         removables.addAll(buildConfigs().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
         removables.addAll(imageStreams().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
-        removables.addAll(endpoints().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
         removables.addAll(services().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
         removables.addAll(builds().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());
         removables.addAll(routes().withLabelNotIn(OpenShift.KEEP_LABEL, "", "true").list().getItems());


### PR DESCRIPTION
**This is related to [#639].**

This is related to [CVE-2021-25740](https://github.com/kubernetes/kubernetes/issues/103675) . XTF's OpenShift.clean() calls endpoints().delete() and endpoints().list(), which require Endpoints write/read permissions. On OCP 4.21,  users with the standard edit or admin role no longer have Endpoints write access, causing a 403 KubernetesClientException that aborts the entire cleanup - leaving services, pods, routes, and everything after the endpoints call uncleaned.                            

**Why do we see it now:**

Even this change was implemented in Kubernetes 1.22, we see the it first time in OCP 4.21 (Kubernetes 1.34) because until OCP 4.20, Openshift was reverting this with each release, because this issue was evaluated by RedHat as not affected. Recently it was removed from list of patches applied with each OCP release.

**What has been changed**

_The endpoints() call in Openshift.clean() and listRemovableResources()._
This endpoints are managed by Service resource.

_Openshift.createEndpoint and Openshift.deleteEndpoint()_
They will work only when user with edit role on Endpoints is used - [Write access for endpoints](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#write-access-for-endpoints)

_Deprecated EndpointBuilder_
Endpoints were [deprecated](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) in Kubernetes v1.33.

_OpenshiftApplication_
- Removes the wiring on Endpoints which was anyway not packed into the application.

**Links**
[CVE-2021-25740: Endpoint & EndpointSlice permissions allow cross-Namespace forwarding · Issue #103675 · kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/issues/103675) 

[Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#write-access-for-endpoints) 

[1982470 – (CVE-2021-25740) CVE-2021-25740 kubernetes: Endpoint & EndpointSlice permissions allow cross-Namespace forwarding](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2021-25740) 

[Revert "Remove Endpoints write access from aggregated edit role" by danwinship · Pull Request #908 · openshift/kubernetes](https://github.com/openshift/kubernetes/pull/908)

## Summary by Sourcery

Adjust OpenShift cleanup and application wiring to avoid relying on Endpoints resources that now require elevated permissions, and mark legacy Endpoints usage as deprecated in favor of EndpointSlice.

Bug Fixes:
- Prevent OpenShift.clean() and listRemovableResources() from failing when Endpoints write access is not available by no longer including Endpoints in the default cleanup/removal flow.

Enhancements:
- Document that createEndpoint and deleteEndpoint require roles with Endpoints write permissions.
- Deprecate EndpointBuilder in favor of EndpointSlice to align with Kubernetes deprecation of Endpoints.
- Remove Endpoints from OpenShiftApplication resource wiring since they were not effectively part of the packaged application.