### PR TITLE
Replace fluent nested Volume builders with direct model construction

### DIFF
--- a/builder/src/main/java/cz/xtf/builder/builders/pod/ConfigMapVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/ConfigMapVolume.java
@@ -1,7 +1,7 @@
 package cz.xtf.builder.builders.pod;
 
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeFluent;
 
 public class ConfigMapVolume extends Volume {
     private final String configMapName;
@@ -24,16 +24,16 @@ public class ConfigMapVolume extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-        VolumeFluent<VolumeBuilder>.ConfigMapNested<VolumeBuilder> cfm = builder.withNewConfigMap();
-        cfm.withName(configMapName);
+        final ConfigMapVolumeSourceBuilder cmb = new ConfigMapVolumeSourceBuilder()
+                .withName(configMapName);
         if (defaultMode != null) {
             int defaultModeIntVal = 0;
             for (byte b : defaultMode.getBytes()) {
                 int num = Character.getNumericValue(b);
                 defaultModeIntVal = num | defaultModeIntVal << 3;
             }
-            cfm.withDefaultMode(defaultModeIntVal);
+            cmb.withDefaultMode(defaultModeIntVal);
         }
-        cfm.endConfigMap();
+        builder.withConfigMap(cmb.build());
     }
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/EmptyDirVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/EmptyDirVolume.java
@@ -1,5 +1,6 @@
 package cz.xtf.builder.builders.pod;
 
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 
 public class EmptyDirVolume extends Volume {
@@ -10,6 +11,6 @@ public class EmptyDirVolume extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-        builder.withNewEmptyDir().endEmptyDir();
+        builder.withEmptyDir(new EmptyDirVolumeSourceBuilder().build());
     }
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/HostPathVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/HostPathVolume.java
@@ -1,5 +1,6 @@
 package cz.xtf.builder.builders.pod;
 
+import io.fabric8.kubernetes.api.model.HostPathVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 
 public class HostPathVolume extends Volume {
@@ -16,8 +17,8 @@ public class HostPathVolume extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-        builder.withNewHostPath()
+        builder.withHostPath(new HostPathVolumeSourceBuilder()
                 .withPath(getSourceHostDirPath())
-                .endHostPath();
+                .build());
     }
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/NFSVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/NFSVolume.java
@@ -1,5 +1,6 @@
 package cz.xtf.builder.builders.pod;
 
+import io.fabric8.kubernetes.api.model.NFSVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 
 public class NFSVolume extends Volume {
@@ -22,9 +23,9 @@ public class NFSVolume extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-        builder.withNewNfs()
+        builder.withNfs(new NFSVolumeSourceBuilder()
                 .withServer(getServer())
                 .withPath(getServerPath())
-                .endNfs();
+                .build());
     }
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/PersistentVolumeClaim.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/PersistentVolumeClaim.java
@@ -1,5 +1,6 @@
 package cz.xtf.builder.builders.pod;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 
 public class PersistentVolumeClaim extends Volume {
@@ -17,9 +18,10 @@ public class PersistentVolumeClaim extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-        builder.withNewPersistentVolumeClaim()
-                .withClaimName(getClaimName())
-                .endPersistentVolumeClaim();
+        builder.withPersistentVolumeClaim(
+                new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName(getClaimName())
+                        .build());
     }
 
 }

--- a/builder/src/main/java/cz/xtf/builder/builders/pod/SecretVolume.java
+++ b/builder/src/main/java/cz/xtf/builder/builders/pod/SecretVolume.java
@@ -2,8 +2,9 @@ package cz.xtf.builder.builders.pod;
 
 import java.util.Map;
 
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeFluent;
 
 public class SecretVolume extends Volume {
     private final String secretName;
@@ -27,14 +28,12 @@ public class SecretVolume extends Volume {
 
     @Override
     protected void addVolumeParameters(VolumeBuilder builder) {
-
-        final VolumeFluent<VolumeBuilder>.SecretNested<VolumeBuilder> volumeBuilderSecretNested = builder.withNewSecret()
+        final SecretVolumeSourceBuilder svb = new SecretVolumeSourceBuilder()
                 .withSecretName(getSecretName());
-
         if (items != null) {
-            items.forEach((key, value) -> volumeBuilderSecretNested.addNewItem().withKey(key).withPath(value).endItem());
+            items.forEach((key, value) -> svb.addToItems(
+                    new KeyToPathBuilder().withKey(key).withPath(value).build()));
         }
-
-        volumeBuilderSecretNested.endSecret();
+        builder.withSecret(svb.build());
     }
 }

--- a/builder/src/test/java/cz/xtf/builder/builders/pod/VolumeBuilderTest.java
+++ b/builder/src/test/java/cz/xtf/builder/builders/pod/VolumeBuilderTest.java
@@ -1,0 +1,151 @@
+package cz.xtf.builder.builders.pod;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+
+/**
+ * Tests that each Volume subclass (new code using explicit source builders) produces the same
+ * Kubernetes Volume object as the old code (fluent nested builders like withNewConfigMap()...endConfigMap()).
+ */
+public class VolumeBuilderTest {
+
+    @Test
+    public void testConfigMapVolume() {
+        // old code: builder.withNewConfigMap().withName(configMapName).endConfigMap()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-cm")
+                .withNewConfigMap()
+                .withName("my-config")
+                .endConfigMap()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new ConfigMapVolume("vol-cm", "my-config").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testConfigMapVolumeWithDefaultMode() {
+        // 0755 octal = 493 decimal
+        // old code: builder.withNewConfigMap().withName(configMapName).withDefaultMode(493).endConfigMap()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-cm2")
+                .withNewConfigMap()
+                .withName("my-config")
+                .withDefaultMode(493)
+                .endConfigMap()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new ConfigMapVolume("vol-cm2", "my-config", "0755").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEmptyDirVolume() {
+        // old code: builder.withNewEmptyDir().endEmptyDir()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-empty")
+                .withNewEmptyDir()
+                .endEmptyDir()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new EmptyDirVolume("vol-empty").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testHostPathVolume() {
+        // old code: builder.withNewHostPath().withPath(path).endHostPath()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-host")
+                .withNewHostPath()
+                .withPath("/data/logs")
+                .endHostPath()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new HostPathVolume("vol-host", "/data/logs").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testNFSVolume() {
+        // old code: builder.withNewNfs().withServer(server).withPath(path).endNfs()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-nfs")
+                .withNewNfs()
+                .withServer("nfs.example.com")
+                .withPath("/exports/data")
+                .endNfs()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new NFSVolume("vol-nfs", "nfs.example.com", "/exports/data").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPersistentVolumeClaim() {
+        // old code: builder.withNewPersistentVolumeClaim().withClaimName(name).endPersistentVolumeClaim()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-pvc")
+                .withNewPersistentVolumeClaim()
+                .withClaimName("my-claim")
+                .endPersistentVolumeClaim()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new PersistentVolumeClaim("vol-pvc", "my-claim").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSecretVolume() {
+        // old code: builder.withNewSecret().withSecretName(name).endSecret()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-secret")
+                .withNewSecret()
+                .withSecretName("my-secret")
+                .endSecret()
+                .build();
+
+        // new code
+        io.fabric8.kubernetes.api.model.Volume actual = new SecretVolume("vol-secret", "my-secret").build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSecretVolumeWithItems() {
+        // old code: builder.withNewSecret().withSecretName(name).addNewItem().withKey(k).withPath(v).endItem()...endSecret()
+        io.fabric8.kubernetes.api.model.Volume expected = new VolumeBuilder()
+                .withName("vol-secret2")
+                .withNewSecret()
+                .withSecretName("my-secret")
+                .addNewItem().withKey("username").withPath("config/user.txt").endItem()
+                .addNewItem().withKey("password").withPath("config/pass.txt").endItem()
+                .endSecret()
+                .build();
+
+        // new code
+        Map<String, String> items = new LinkedHashMap<>();
+        items.put("username", "config/user.txt");
+        items.put("password", "config/pass.txt");
+        io.fabric8.kubernetes.api.model.Volume actual = new SecretVolume("vol-secret2", "my-secret", items).build();
+
+        Assertions.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/xtf-cz/xtf/issues/644

## Summary

- Replace fluent nested builder calls (`withNewXxx()...endXxx()`) with direct
  model object construction (`withXxx(new XxxVolumeSourceBuilder()...build())`)
  in all six Volume subclasses
- Eliminates runtime `NoSuchMethodError` on `VolumeFluent$XxxNested` inner class
  resolution during Maven Failsafe execution

## Problem

All Volume subclasses in `cz.xtf.builder.builders.pod` use VolumeBuilder fluent
nested builder methods that return `VolumeFluent$XxxNested` inner classes.
Despite correct bytecode compatibility with fabric8 7.4.0 at compile time, these
methods fail with `NoSuchMethodError` at runtime when executed in Maven
Failsafe's forked JVM.

## Fix
  
Replace the fluent nested builder pattern:
```java
  builder.withNewPersistentVolumeClaim()
      .withClaimName(claimName)
      .endPersistentVolumeClaim();

  With direct model object construction:
  builder.withPersistentVolumeClaim(
      new PersistentVolumeClaimVolumeSourceBuilder()
          .withClaimName(claimName)
          .build());
```
This avoids the VolumeFluent$XxxNested inner class resolution entirely while  producing identical Kubernetes Volume objects.

Please make sure your PR meets the following requirements:
- [x] Pull Request contains a description of the changes
- [x] Pull Request does not include fixes for multiple issues/topics
- [x] Code is formatted, imports ordered, code compiles and tests are passing
- [x] Code is self-descriptive and/or documented

## Summary by Sourcery

Replace fluent nested volume configuration with direct Kubernetes volume source construction in all volume builder implementations.

Bug Fixes:
- Avoid runtime NoSuchMethodError caused by use of VolumeFluent nested builders for various volume types.

Enhancements:
- Use direct *VolumeSourceBuilder model instances for Secret, ConfigMap, PVC, HostPath, NFS, and EmptyDir volumes, including explicit key-to-path item mapping for Secret volumes.